### PR TITLE
P0-1: Field-level writes, idempotency keys, and indexes

### DIFF
--- a/apps/lab/app/src/lib/api.ts
+++ b/apps/lab/app/src/lib/api.ts
@@ -63,7 +63,7 @@ export async function advance(
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		credentials: "include",
-		body: JSON.stringify({ target }),
+		body: JSON.stringify({ target, idempotencyKey: crypto.randomUUID() }),
 	});
 	if (!r.ok) throw new Error("Failed to advance");
 	return r.json();
@@ -77,7 +77,7 @@ export async function submitEvent(
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		credentials: "include",
-		body: JSON.stringify(event),
+		body: JSON.stringify({ ...event, idempotencyKey: crypto.randomUUID() }),
 	});
 	if (!r.ok) throw new Error("Failed to submit event");
 	return r.json();

--- a/apps/lab/server/src/index.ts
+++ b/apps/lab/server/src/index.ts
@@ -7,6 +7,7 @@ import { resolve } from "node:path";
 import { cors } from "@elysiajs/cors";
 import { auth } from "@pairit/auth";
 import { Elysia } from "elysia";
+import { ensureIndexes } from "./lib/db";
 import { configsRoutes } from "./routes/configs";
 import { eventsRoutes } from "./routes/events";
 import { sessionsRoutes } from "./routes/sessions";
@@ -113,3 +114,7 @@ app.listen(Number(process.env.PORT) || 3001);
 console.log(
 	`🚀 Lab server running on ${app.server?.hostname}:${app.server?.port}`,
 );
+
+ensureIndexes().catch((err) => {
+	console.error("[DB] Failed to ensure indexes:", err);
+});

--- a/apps/lab/server/src/types.ts
+++ b/apps/lab/server/src/types.ts
@@ -74,5 +74,11 @@ export type Event = {
 };
 
 export type EventDocument = Event & {
+	idempotencyKey: string;
+	createdAt: Date;
+};
+
+export type IdempotencyRecord = {
+	key: string;
 	createdAt: Date;
 };


### PR DESCRIPTION
## Summary

Fixes foundational issues identified in Google SWE review:
- **Field-level writes**: `advanceSession()` now uses `$set` on specific fields instead of full document overwrites, preventing race conditions
- **Idempotency keys**: Both advance and event endpoints require and validate idempotency keys to handle network retries safely
- **Database indexes**: Auto-created on startup for sessions, events, configs, and idempotency_keys collections

## Changes

- Replace `saveSession` with `createSession` (insertOne) for new sessions
- Add `advanceSession` using field-level `$set` instead of full doc overwrite
- Add `updateUserState()` for future dot-notation nested field updates
- Add `ensureIndexes()` called on server startup
- Client sends `crypto.randomUUID()` as idempotencyKey on advance/events

## Indexes Created

| Collection | Index | Options |
|------------|-------|---------|
| sessions | `id` | unique |
| events | `sessionId + createdAt` | compound |
| events | `idempotencyKey` | unique, sparse |
| configs | `configId` | unique |
| idempotency_keys | `key` | unique |
| idempotency_keys | `createdAt` | TTL: 24h |

## Test Plan

- [x] **Indexes exist**: Check Atlas → Browse Collections → Indexes tab
- [x] **Basic flow**: Complete session at http://localhost:3000/hello-world
- [x] **Events have idempotencyKey**: Check `events` collection in Atlas
- [x] **Idempotency works**: Run same curl twice, second returns `deduplicated: true`

```bash
# Test idempotency (run twice - second should return deduplicated: true)
curl -X POST http://localhost:3001/sessions/<SESSION_UUID>/advance \
  -H "Content-Type: application/json" \
  -d '{"target":"page2","idempotencyKey":"test-123"}'
```

🤖 Generated with [Claude Code](https://claude.ai/code)

Closes #14