### PR TITLE
Add SSE transport layer for real-time events

### DIFF
--- a/apps/lab/server/src/index.ts
+++ b/apps/lab/server/src/index.ts
@@ -11,6 +11,7 @@ import { ensureIndexes } from "./lib/db";
 import { configsRoutes } from "./routes/configs";
 import { eventsRoutes } from "./routes/events";
 import { sessionsRoutes } from "./routes/sessions";
+import { streamRoutes } from "./routes/stream";
 
 const IS_DEV = process.env.NODE_ENV === "development";
 const RAW_CORS_ORIGINS = process.env.CORS_ORIGINS;
@@ -82,7 +83,8 @@ app
 	// API Routes
 	.use(configsRoutes)
 	.use(sessionsRoutes)
-	.use(eventsRoutes);
+	.use(eventsRoutes)
+	.use(streamRoutes);
 
 // Static file serving (production only - in dev, Vite handles this)
 if (!IS_DEV) {

--- a/apps/lab/server/src/lib/sse.ts
+++ b/apps/lab/server/src/lib/sse.ts
@@ -1,0 +1,150 @@
+/**
+ * SSE Connection Manager
+ * Manages server-sent event connections and broadcasts
+ */
+
+import { getSessionsCollection } from "./db";
+
+export type SSEEvent = {
+	event: string;
+	data: unknown;
+};
+
+export type SSEController = {
+	send: (event: string, data: unknown) => void;
+	close: () => void;
+};
+
+/**
+ * Simple async queue for SSE events
+ * Allows pushing events that can be consumed by an async iterator
+ */
+export class AsyncEventQueue {
+	private queue: SSEEvent[] = [];
+	private resolvers: ((value: SSEEvent) => void)[] = [];
+	private closed = false;
+
+	push(event: SSEEvent): void {
+		if (this.closed) return;
+
+		const resolver = this.resolvers.shift();
+		if (resolver) {
+			resolver(event);
+		} else {
+			this.queue.push(event);
+		}
+	}
+
+	async pop(): Promise<SSEEvent | null> {
+		if (this.closed && this.queue.length === 0) return null;
+
+		const queued = this.queue.shift();
+		if (queued) {
+			return queued;
+		}
+
+		if (this.closed) return null;
+
+		return new Promise((resolve) => {
+			this.resolvers.push(resolve);
+		});
+	}
+
+	close(): void {
+		this.closed = true;
+		// Resolve any pending waiters with null
+		for (const resolver of this.resolvers) {
+			resolver({ event: "__closed__", data: null });
+		}
+		this.resolvers = [];
+	}
+
+	isClosed(): boolean {
+		return this.closed;
+	}
+}
+
+// Map<sessionId, Set<SSEController>> - multiple tabs = multiple controllers
+const connections = new Map<string, Set<SSEController>>();
+
+export function addConnection(
+	sessionId: string,
+	controller: SSEController,
+): void {
+	let sessionConnections = connections.get(sessionId);
+	if (!sessionConnections) {
+		sessionConnections = new Set();
+		connections.set(sessionId, sessionConnections);
+	}
+	sessionConnections.add(controller);
+	console.log(
+		`[SSE] Connection added for session ${sessionId} (total: ${sessionConnections.size})`,
+	);
+}
+
+export function removeConnection(
+	sessionId: string,
+	controller: SSEController,
+): void {
+	const sessionConnections = connections.get(sessionId);
+	if (sessionConnections) {
+		sessionConnections.delete(controller);
+		console.log(
+			`[SSE] Connection removed for session ${sessionId} (remaining: ${sessionConnections.size})`,
+		);
+		if (sessionConnections.size === 0) {
+			connections.delete(sessionId);
+		}
+	}
+}
+
+export function broadcastToSession(
+	sessionId: string,
+	event: string,
+	data: unknown,
+): void {
+	const sessionConnections = connections.get(sessionId);
+	if (!sessionConnections) {
+		console.log(`[SSE] No connections for session ${sessionId}`);
+		return;
+	}
+
+	console.log(
+		`[SSE] Broadcasting '${event}' to ${sessionConnections.size} connection(s) for session ${sessionId}`,
+	);
+	for (const controller of sessionConnections) {
+		controller.send(event, data);
+	}
+}
+
+export async function broadcastToGroup(
+	groupId: string,
+	event: string,
+	data: unknown,
+): Promise<void> {
+	// Look up sessions by group_id in MongoDB
+	const collection = await getSessionsCollection();
+	const sessions = await collection
+		.find({ "user_state.group_id": groupId })
+		.project({ id: 1 })
+		.toArray();
+
+	console.log(
+		`[SSE] Broadcasting '${event}' to group ${groupId} (${sessions.length} sessions)`,
+	);
+	for (const session of sessions) {
+		broadcastToSession(session.id, event, data);
+	}
+}
+
+export function getConnectionCount(sessionId: string): number {
+	return connections.get(sessionId)?.size ?? 0;
+}
+
+export function getTotalConnectionCount(): number {
+	let total = 0;
+	for (const sessionConnections of connections.values()) {
+		total += sessionConnections.size;
+	}
+	return total;
+}

--- a/apps/lab/server/src/routes/sessions.ts
+++ b/apps/lab/server/src/routes/sessions.ts
@@ -105,7 +105,7 @@ function uid(): string {
 	return randomUUID();
 }
 
-async function loadSession(sessionId: string): Promise<Session | null> {
+export async function loadSession(sessionId: string): Promise<Session | null> {
 	const collection = await getSessionsCollection();
 	const data = await collection.findOne({ id: sessionId });
 	if (!data) return null;

--- a/apps/lab/server/src/routes/stream.ts
+++ b/apps/lab/server/src/routes/stream.ts
@@ -1,0 +1,99 @@
+/**
+ * SSE Stream routes for lab server
+ * GET /sessions/:id/stream - Server-sent events stream
+ */
+
+import { Elysia, sse, t } from "elysia";
+import {
+	AsyncEventQueue,
+	addConnection,
+	broadcastToSession,
+	removeConnection,
+	type SSEController,
+} from "../lib/sse";
+import { loadSession } from "./sessions";
+
+const HEARTBEAT_INTERVAL = 30000; // 30 seconds
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export const streamRoutes = new Elysia({ prefix: "/sessions" })
+	.get(
+		"/:id/stream",
+		async function* ({ params: { id }, set }) {
+			// Verify session exists
+			const session = await loadSession(id);
+			if (!session) {
+				set.status = 404;
+				return;
+			}
+
+			// Create event queue for this connection
+			const queue = new AsyncEventQueue();
+
+			// Create controller for this connection
+			const controller: SSEController = {
+				send: (event, data) => {
+					queue.push({ event, data });
+				},
+				close: () => {
+					queue.close();
+				},
+			};
+
+			addConnection(id, controller);
+
+			try {
+				// Send initial connected event
+				yield sse({ event: "connected", data: { sessionId: id } });
+
+				// Start heartbeat in background
+				let heartbeatActive = true;
+				const heartbeatLoop = async () => {
+					while (heartbeatActive && !queue.isClosed()) {
+						await sleep(HEARTBEAT_INTERVAL);
+						if (heartbeatActive && !queue.isClosed()) {
+							queue.push({ event: "heartbeat", data: { ts: Date.now() } });
+						}
+					}
+				};
+				heartbeatLoop(); // Fire and forget
+
+				// Yield events from queue
+				while (!queue.isClosed()) {
+					const evt = await queue.pop();
+					if (evt === null || evt.event === "__closed__") break;
+					yield sse(evt);
+				}
+
+				heartbeatActive = false;
+			} finally {
+				removeConnection(id, controller);
+			}
+		},
+		{
+			params: t.Object({ id: t.String() }),
+		},
+	)
+	// Test endpoint for verifying broadcast functionality (development only)
+	.get(
+		"/:id/test-broadcast",
+		async ({ params: { id }, set }) => {
+			const session = await loadSession(id);
+			if (!session) {
+				set.status = 404;
+				return { error: "not_found" };
+			}
+
+			broadcastToSession(id, "test", {
+				message: "hello from test-broadcast",
+				ts: Date.now(),
+			});
+			return { sent: true };
+		},
+		{
+			params: t.Object({ id: t.String() }),
+		},
+	);


### PR DESCRIPTION
## Summary

- Add connection manager (`sse.ts`) with per-session connection tracking
- Add `GET /sessions/:id/stream` SSE endpoint with proper `text/event-stream` content type
- Support multiple connections per session (multiple tabs)
- Add `broadcastToSession()` and `broadcastToGroup()` helpers
- Include heartbeat every 30s and `connected` event on connect

## Test plan

- [x] SSE endpoint returns `text/event-stream` content type
- [x] `connected` event sent on connection
- [x] Multiple connections per session work (tabs)
- [x] Broadcast sends events to all connections
- [x] Heartbeat arrives every 30 seconds
- [x] Invalid session returns 404
- [x] Browser EventSource works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

Closes #16