### PR TITLE
Add chat backend and frontend infrastructure

### DIFF
--- a/apps/lab/app/src/App.tsx
+++ b/apps/lab/app/src/App.tsx
@@ -9,6 +9,7 @@ import {
 	advance,
 	startSession,
 } from "./lib/api";
+import { sseClient } from "./lib/sse";
 import { useSession } from "./lib/auth-client";
 import { loadConfig } from "./runtime";
 import type { CompiledConfig } from "./runtime/config";
@@ -185,6 +186,13 @@ export default function App() {
 			canceled = true;
 		};
 	}, [experimentId, authLoading, isAuthenticated]);
+
+	// Connect SSE when session is available
+	useEffect(() => {
+		if (!sessionId) return;
+		sseClient.connect(sessionId);
+		return () => sseClient.disconnect();
+	}, [sessionId]);
 
 	async function onAction(a: { type: "go_to"; target: string }) {
 		if (mode === "local" && compiledConfig) {

--- a/apps/lab/app/src/components/Chat/ChatView.tsx
+++ b/apps/lab/app/src/components/Chat/ChatView.tsx
@@ -1,0 +1,167 @@
+/**
+ * ChatView - Presentational chat component
+ * Displays messages and input field with auto-scroll
+ */
+
+import { useEffect, useRef, useState } from "react";
+import Markdown from "react-markdown";
+
+export type ChatMessage = {
+	messageId: string;
+	senderId: string;
+	senderType: "participant" | "agent" | "system";
+	content: string;
+	createdAt: string;
+	isOwn?: boolean;
+};
+
+export type ChatViewProps = {
+	messages: ChatMessage[];
+	onSend: (content: string) => void;
+	disabled?: boolean;
+	placeholder?: string;
+};
+
+export function ChatView({
+	messages,
+	onSend,
+	disabled = false,
+	placeholder = "Type a message...",
+}: ChatViewProps) {
+	const [input, setInput] = useState("");
+	const messagesEndRef = useRef<HTMLDivElement>(null);
+	const inputRef = useRef<HTMLTextAreaElement>(null);
+
+	// Auto-scroll to bottom when new messages arrive
+	// biome-ignore lint/correctness/useExhaustiveDependencies: We intentionally trigger scroll on messages.length change
+	useEffect(() => {
+		messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+	}, [messages.length]);
+
+	// Focus input on mount
+	useEffect(() => {
+		inputRef.current?.focus();
+	}, []);
+
+	const handleSubmit = (e?: React.FormEvent) => {
+		e?.preventDefault();
+		const trimmed = input.trim();
+		if (!trimmed || disabled) return;
+
+		onSend(trimmed);
+		setInput("");
+	};
+
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+		if (e.key === "Enter" && !e.shiftKey) {
+			e.preventDefault();
+			handleSubmit();
+		}
+	};
+
+	return (
+		<div className="flex h-[500px] flex-col rounded-2xl border border-slate-200 bg-white">
+			{/* Messages area */}
+			<div className="flex-1 space-y-3 overflow-y-auto p-4">
+				{messages.length === 0 && (
+					<div className="flex h-full items-center justify-center text-sm text-slate-400">
+						No messages yet
+					</div>
+				)}
+				{messages.map((message) => (
+					<MessageBubble key={message.messageId} message={message} />
+				))}
+				<div ref={messagesEndRef} />
+			</div>
+
+			{/* Input area */}
+			<form
+				onSubmit={handleSubmit}
+				className="flex gap-2 border-t border-slate-200 p-4"
+			>
+				<textarea
+					ref={inputRef}
+					value={input}
+					onChange={(e) => setInput(e.target.value)}
+					onKeyDown={handleKeyDown}
+					placeholder={placeholder}
+					disabled={disabled}
+					rows={1}
+					className="flex-1 resize-none rounded-lg border border-slate-200 px-3 py-2 text-sm transition-colors focus:border-slate-400 focus:outline-none disabled:bg-slate-50 disabled:text-slate-400"
+				/>
+				<button
+					type="submit"
+					disabled={disabled || !input.trim()}
+					className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-300"
+				>
+					Send
+				</button>
+			</form>
+		</div>
+	);
+}
+
+function MessageBubble({ message }: { message: ChatMessage }) {
+	const isOwn = message.isOwn;
+	const isAgent = message.senderType === "agent";
+	const isSystem = message.senderType === "system";
+
+	// Determine bubble styling
+	let bubbleClasses = "max-w-[80%] rounded-2xl px-4 py-2 text-sm";
+	let alignmentClasses = "flex";
+
+	if (isSystem) {
+		// System messages: centered, muted
+		alignmentClasses = "flex justify-center";
+		bubbleClasses =
+			"rounded-lg bg-slate-100 px-3 py-1.5 text-xs text-slate-500 italic";
+	} else if (isOwn) {
+		// Own messages: right-aligned, dark background
+		alignmentClasses = "flex justify-end";
+		bubbleClasses += " bg-slate-900 text-white";
+	} else if (isAgent) {
+		// Agent messages: left-aligned, blue background
+		alignmentClasses = "flex justify-start";
+		bubbleClasses += " bg-blue-500 text-white";
+	} else {
+		// Other participant messages: left-aligned, light background
+		alignmentClasses = "flex justify-start";
+		bubbleClasses += " bg-slate-100 text-slate-900";
+	}
+
+	return (
+		<div className={alignmentClasses}>
+			<div className={bubbleClasses}>
+				<div className="prose prose-sm max-w-none prose-p:my-0 prose-p:leading-relaxed prose-headings:my-1 prose-ul:my-1 prose-ol:my-1 prose-li:my-0 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0">
+					{isOwn || isAgent ? (
+						<Markdown
+							components={{
+								// Override text color for dark backgrounds
+								p: ({ children }) => <p className="text-inherit">{children}</p>,
+								a: ({ children, href }) => (
+									<a
+										href={href}
+										className="text-inherit underline"
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										{children}
+									</a>
+								),
+								code: ({ children }) => (
+									<code className="rounded bg-white/20 px-1 py-0.5 text-inherit">
+										{children}
+									</code>
+								),
+							}}
+						>
+							{message.content}
+						</Markdown>
+					) : (
+						<Markdown>{message.content}</Markdown>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/lab/app/src/components/Chat/runtime.tsx
+++ b/apps/lab/app/src/components/Chat/runtime.tsx
@@ -1,0 +1,205 @@
+/**
+ * Chat Runtime - Connects ChatView to the runtime system
+ * Handles SSE subscription, message history, and event emission
+ */
+
+import {
+	type ChatMessage as ApiChatMessage,
+	getChatHistory,
+	sendChatMessage,
+	submitEvent,
+} from "@app/lib/api";
+import { sseClient } from "@app/lib/sse";
+import { defineRuntimeComponent } from "@app/runtime/define-runtime-component";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { type ChatMessage, ChatView } from "./ChatView";
+
+type ChatProps = {
+	placeholder?: string;
+};
+
+type SSEChatMessage = {
+	messageId: string;
+	groupId: string;
+	sessionId: string;
+	senderId: string;
+	senderType: "participant" | "agent" | "system";
+	content: string;
+	createdAt: string;
+};
+
+export const ChatRuntime = defineRuntimeComponent<"chat", ChatProps>({
+	type: "chat",
+	renderer: ({ component, context }) => {
+		const { sessionId, userState } = context;
+		const [messages, setMessages] = useState<ChatMessage[]>([]);
+		const [loading, setLoading] = useState(true);
+		const seenMessageIds = useRef<Set<string>>(new Set());
+
+		// Resolve groupId: use chat_group_id from userState or fall back to sessionId
+		const groupId = (userState?.chat_group_id as string) || sessionId || "";
+
+		// Convert API message to ChatMessage with isOwn flag
+		const toViewMessage = useCallback(
+			(msg: ApiChatMessage | SSEChatMessage): ChatMessage => ({
+				messageId: msg.messageId,
+				senderId: msg.senderId,
+				senderType: msg.senderType,
+				content: msg.content,
+				createdAt: msg.createdAt,
+				isOwn: msg.senderId === sessionId,
+			}),
+			[sessionId],
+		);
+
+		// Load history on mount
+		useEffect(() => {
+			if (!sessionId || !groupId) return;
+
+			let canceled = false;
+			const currentSessionId = sessionId;
+			const currentGroupId = groupId;
+
+			async function loadHistory() {
+				try {
+					const { messages: history } = await getChatHistory(
+						currentGroupId,
+						currentSessionId,
+					);
+					if (canceled) return;
+
+					// Track seen message IDs
+					for (const msg of history) {
+						seenMessageIds.current.add(msg.messageId);
+					}
+
+					setMessages(history.map(toViewMessage));
+				} catch (error) {
+					console.error("[Chat] Failed to load history:", error);
+				} finally {
+					if (!canceled) setLoading(false);
+				}
+			}
+
+			loadHistory();
+
+			return () => {
+				canceled = true;
+			};
+		}, [sessionId, groupId, toViewMessage]);
+
+		// Subscribe to SSE chat_message events
+		useEffect(() => {
+			if (!sessionId || !groupId) return;
+
+			const currentSessionId = sessionId;
+
+			const unsubscribe = sseClient.on("chat_message", (data) => {
+				const message = data as SSEChatMessage;
+
+				// Only process messages for our group
+				if (message.groupId !== groupId) return;
+
+				// Dedupe by messageId
+				if (seenMessageIds.current.has(message.messageId)) return;
+				seenMessageIds.current.add(message.messageId);
+
+				setMessages((prev) => [...prev, toViewMessage(message)]);
+
+				// Emit onMessageReceive event if configured
+				if (
+					component.events?.onMessageReceive &&
+					message.senderId !== currentSessionId
+				) {
+					void emitChatEvent(
+						component.id,
+						currentSessionId,
+						component.events.onMessageReceive,
+						{
+							messageId: message.messageId,
+							senderId: message.senderId,
+							senderType: message.senderType,
+						},
+					);
+				}
+			});
+
+			return unsubscribe;
+		}, [sessionId, groupId, toViewMessage, component.events, component.id]);
+
+		// Handle sending messages
+		const handleSend = useCallback(
+			async (content: string) => {
+				if (!sessionId || !groupId) return;
+
+				try {
+					const result = await sendChatMessage(groupId, sessionId, content);
+
+					// Emit onMessageSend event if configured
+					if (component.events?.onMessageSend) {
+						void emitChatEvent(
+							component.id,
+							sessionId,
+							component.events.onMessageSend,
+							{
+								messageId: result.messageId,
+								content,
+							},
+						);
+					}
+				} catch (error) {
+					console.error("[Chat] Failed to send message:", error);
+				}
+			},
+			[sessionId, groupId, component.id, component.events],
+		);
+
+		if (!sessionId) {
+			return (
+				<div className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+					Chat requires an active session.
+				</div>
+			);
+		}
+
+		if (loading) {
+			return (
+				<div className="flex h-[500px] items-center justify-center rounded-2xl border border-slate-200 bg-white">
+					<div className="text-sm text-slate-400">Loading chat...</div>
+				</div>
+			);
+		}
+
+		return (
+			<ChatView
+				messages={messages}
+				onSend={handleSend}
+				placeholder={component.props.placeholder}
+			/>
+		);
+	},
+});
+
+async function emitChatEvent(
+	componentId: string | undefined,
+	sessionId: string | null | undefined,
+	eventConfig: { type?: string; data?: Record<string, unknown> },
+	eventData: Record<string, unknown>,
+) {
+	if (!sessionId) return;
+
+	try {
+		await submitEvent(sessionId, {
+			type: eventConfig.type ?? "chat_event",
+			timestamp: new Date().toISOString(),
+			componentType: "chat",
+			componentId: componentId ?? "unknown",
+			data: {
+				...eventConfig.data,
+				...eventData,
+			},
+		});
+	} catch (error) {
+		console.error("[Chat] Failed to submit event:", error);
+	}
+}

--- a/apps/lab/app/src/components/runtime.ts
+++ b/apps/lab/app/src/components/runtime.ts
@@ -3,3 +3,4 @@ import "./ui/Button/runtime";
 import "./ui/Media/runtime";
 import "./Survey/runtime";
 import "./PagedSurvey/runtime";
+import "./Chat/runtime";

--- a/apps/lab/app/src/lib/api.ts
+++ b/apps/lab/app/src/lib/api.ts
@@ -95,3 +95,58 @@ export async function updateState(
 	});
 	if (!r.ok) throw new Error("Failed to update state");
 }
+
+// Chat API
+
+export type ChatMessage = {
+	messageId: string;
+	groupId: string;
+	sessionId: string;
+	senderId: string;
+	senderType: "participant" | "agent" | "system";
+	content: string;
+	createdAt: string;
+};
+
+type SendChatMessageResponse = {
+	messageId: string;
+	createdAt: string;
+	deduplicated?: boolean;
+};
+
+type GetChatHistoryResponse = {
+	messages: ChatMessage[];
+};
+
+export async function sendChatMessage(
+	groupId: string,
+	sessionId: string,
+	content: string,
+): Promise<SendChatMessageResponse> {
+	const r = await fetch(`${baseUrl}/chat/${groupId}/send`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		credentials: "include",
+		body: JSON.stringify({
+			sessionId,
+			content,
+			idempotencyKey: crypto.randomUUID(),
+		}),
+	});
+	if (!r.ok) throw new Error("Failed to send message");
+	return r.json();
+}
+
+export async function getChatHistory(
+	groupId: string,
+	sessionId: string,
+): Promise<GetChatHistoryResponse> {
+	const r = await fetch(
+		`${baseUrl}/chat/${groupId}/history?sessionId=${encodeURIComponent(sessionId)}`,
+		{
+			credentials: "include",
+		},
+	);
+	if (!r.ok) throw new Error("Failed to get chat history");
+	return r.json();
+}

--- a/apps/lab/app/src/lib/sse.ts
+++ b/apps/lab/app/src/lib/sse.ts
@@ -1,0 +1,169 @@
+/**
+ * SSE Client Singleton
+ * Manages server-sent events connection for real-time updates
+ */
+
+type EventListener = (data: unknown) => void;
+
+class SSEClient {
+	private eventSource: EventSource | null = null;
+	private sessionId: string | null = null;
+	private listeners: Map<string, Set<EventListener>> = new Map();
+	private reconnectAttempts = 0;
+	private maxReconnectAttempts = 5;
+	private reconnectDelay = 1000;
+	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+	/**
+	 * Connect to the SSE stream for a session
+	 */
+	connect(sessionId: string): void {
+		// If already connected to this session, skip
+		if (
+			this.sessionId === sessionId &&
+			this.eventSource?.readyState === EventSource.OPEN
+		) {
+			return;
+		}
+
+		// Disconnect from any existing connection
+		this.disconnect();
+
+		this.sessionId = sessionId;
+		this.reconnectAttempts = 0;
+
+		this.createConnection();
+	}
+
+	private createConnection(): void {
+		if (!this.sessionId) return;
+
+		const baseUrl = import.meta.env.VITE_API_URL || "";
+		const url = `${baseUrl}/sessions/${this.sessionId}/stream`;
+
+		console.log(`[SSE] Connecting to ${url}`);
+
+		this.eventSource = new EventSource(url, { withCredentials: true });
+
+		this.eventSource.onopen = () => {
+			console.log("[SSE] Connection opened");
+			this.reconnectAttempts = 0;
+		};
+
+		this.eventSource.onerror = (event) => {
+			console.error("[SSE] Connection error", event);
+
+			if (this.eventSource?.readyState === EventSource.CLOSED) {
+				this.handleDisconnect();
+			}
+		};
+
+		// Listen for all known event types
+		this.eventSource.addEventListener("connected", (event) => {
+			this.dispatchEvent("connected", JSON.parse(event.data));
+		});
+
+		this.eventSource.addEventListener("heartbeat", (event) => {
+			this.dispatchEvent("heartbeat", JSON.parse(event.data));
+		});
+
+		this.eventSource.addEventListener("chat_message", (event) => {
+			this.dispatchEvent("chat_message", JSON.parse(event.data));
+		});
+
+		this.eventSource.addEventListener("page_change", (event) => {
+			this.dispatchEvent("page_change", JSON.parse(event.data));
+		});
+
+		this.eventSource.addEventListener("user_state_change", (event) => {
+			this.dispatchEvent("user_state_change", JSON.parse(event.data));
+		});
+	}
+
+	private handleDisconnect(): void {
+		if (this.reconnectAttempts >= this.maxReconnectAttempts) {
+			console.log("[SSE] Max reconnect attempts reached, giving up");
+			return;
+		}
+
+		const delay = this.reconnectDelay * 2 ** this.reconnectAttempts;
+		this.reconnectAttempts++;
+
+		console.log(
+			`[SSE] Attempting reconnect in ${delay}ms (attempt ${this.reconnectAttempts})`,
+		);
+
+		this.reconnectTimer = setTimeout(() => {
+			this.createConnection();
+		}, delay);
+	}
+
+	/**
+	 * Disconnect from the SSE stream
+	 */
+	disconnect(): void {
+		if (this.reconnectTimer) {
+			clearTimeout(this.reconnectTimer);
+			this.reconnectTimer = null;
+		}
+
+		if (this.eventSource) {
+			console.log("[SSE] Disconnecting");
+			this.eventSource.close();
+			this.eventSource = null;
+		}
+
+		this.sessionId = null;
+	}
+
+	/**
+	 * Subscribe to an event type
+	 * @returns Unsubscribe function
+	 */
+	on(event: string, listener: EventListener): () => void {
+		let eventListeners = this.listeners.get(event);
+		if (!eventListeners) {
+			eventListeners = new Set();
+			this.listeners.set(event, eventListeners);
+		}
+		eventListeners.add(listener);
+
+		// Return unsubscribe function
+		return () => {
+			eventListeners?.delete(listener);
+			if (eventListeners?.size === 0) {
+				this.listeners.delete(event);
+			}
+		};
+	}
+
+	private dispatchEvent(event: string, data: unknown): void {
+		const eventListeners = this.listeners.get(event);
+		if (eventListeners) {
+			for (const listener of eventListeners) {
+				try {
+					listener(data);
+				} catch (error) {
+					console.error(`[SSE] Error in listener for '${event}':`, error);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Check if currently connected
+	 */
+	isConnected(): boolean {
+		return this.eventSource?.readyState === EventSource.OPEN;
+	}
+
+	/**
+	 * Get current session ID
+	 */
+	getSessionId(): string | null {
+		return this.sessionId;
+	}
+}
+
+// Export singleton instance
+export const sseClient = new SSEClient();

--- a/apps/lab/server/src/index.ts
+++ b/apps/lab/server/src/index.ts
@@ -8,6 +8,7 @@ import { cors } from "@elysiajs/cors";
 import { auth } from "@pairit/auth";
 import { Elysia } from "elysia";
 import { ensureIndexes } from "./lib/db";
+import { chatRoutes } from "./routes/chat";
 import { configsRoutes } from "./routes/configs";
 import { eventsRoutes } from "./routes/events";
 import { sessionsRoutes } from "./routes/sessions";
@@ -84,7 +85,8 @@ app
 	.use(configsRoutes)
 	.use(sessionsRoutes)
 	.use(eventsRoutes)
-	.use(streamRoutes);
+	.use(streamRoutes)
+	.use(chatRoutes);
 
 // Static file serving (production only - in dev, Vite handles this)
 if (!IS_DEV) {

--- a/apps/lab/server/src/lib/db.ts
+++ b/apps/lab/server/src/lib/db.ts
@@ -6,6 +6,7 @@
 import { connectDB } from "@pairit/db";
 import type { Collection } from "mongodb";
 import type {
+	ChatMessageDocument,
 	ConfigDocument,
 	EventDocument,
 	IdempotencyRecord,
@@ -42,6 +43,13 @@ export async function getIdempotencyCollection(): Promise<
 	return database.collection<IdempotencyRecord>("idempotency_keys");
 }
 
+export async function getChatMessagesCollection(): Promise<
+	Collection<ChatMessageDocument>
+> {
+	const database = await connectDB();
+	return database.collection<ChatMessageDocument>("chat_messages");
+}
+
 export async function ensureIndexes(): Promise<void> {
 	const database = await connectDB();
 
@@ -63,6 +71,13 @@ export async function ensureIndexes(): Promise<void> {
 	await database
 		.collection("idempotency_keys")
 		.createIndex({ createdAt: 1 }, { expireAfterSeconds: 86400 });
+
+	await database
+		.collection("chat_messages")
+		.createIndex({ groupId: 1, createdAt: 1 });
+	await database
+		.collection("chat_messages")
+		.createIndex({ idempotencyKey: 1 }, { unique: true, sparse: true });
 
 	console.log("[DB] All indexes ensured");
 }

--- a/apps/lab/server/src/routes/chat.ts
+++ b/apps/lab/server/src/routes/chat.ts
@@ -1,0 +1,192 @@
+/**
+ * Chat routes for lab server
+ * POST /chat/:groupId/send - Send a message to a chat group
+ * GET /chat/:groupId/history - Get message history for a chat group
+ */
+
+import { Elysia, t } from "elysia";
+import { MongoServerError, type ObjectId } from "mongodb";
+import { getChatMessagesCollection, getSessionsCollection } from "../lib/db";
+import { broadcastToSession } from "../lib/sse";
+import type { ChatMessageDocument } from "../types";
+
+/**
+ * Verify that a session is a member of a chat group.
+ * - Human-AI chat: groupId === sessionId
+ * - Group chat: session.user_state.chat_group_id === groupId
+ */
+async function verifyMembership(
+	sessionId: string,
+	groupId: string,
+): Promise<boolean> {
+	// Human-AI chat: groupId equals sessionId
+	if (sessionId === groupId) {
+		return true;
+	}
+
+	// Group chat: check user_state.chat_group_id
+	const sessionsCollection = await getSessionsCollection();
+	const session = await sessionsCollection.findOne({ id: sessionId });
+	if (!session) {
+		return false;
+	}
+
+	return session.user_state?.chat_group_id === groupId;
+}
+
+/**
+ * Get all session IDs that are members of a chat group
+ */
+async function getGroupMembers(groupId: string): Promise<string[]> {
+	const sessionsCollection = await getSessionsCollection();
+
+	// Find sessions where user_state.chat_group_id matches
+	const sessions = await sessionsCollection
+		.find({ "user_state.chat_group_id": groupId })
+		.project({ id: 1 })
+		.toArray();
+
+	const memberIds = sessions.map((s) => s.id);
+
+	// Also include the groupId itself (for human-AI chat where groupId === sessionId)
+	if (!memberIds.includes(groupId)) {
+		memberIds.push(groupId);
+	}
+
+	return memberIds;
+}
+
+export const chatRoutes = new Elysia({ prefix: "/chat" })
+	.post(
+		"/:groupId/send",
+		async ({ params: { groupId }, body, set }) => {
+			const { sessionId, content, idempotencyKey, senderType } = body;
+
+			// Verify membership
+			const isMember = await verifyMembership(sessionId, groupId);
+			if (!isMember) {
+				set.status = 403;
+				return { error: "not_a_member" };
+			}
+
+			const collection = await getChatMessagesCollection();
+
+			// Check idempotency if key provided
+			if (idempotencyKey) {
+				const existing = await collection.findOne({ idempotencyKey });
+				if (existing) {
+					return {
+						messageId: existing._id?.toString(),
+						createdAt: existing.createdAt.toISOString(),
+						deduplicated: true,
+					};
+				}
+			}
+
+			const now = new Date();
+			const message: ChatMessageDocument = {
+				groupId,
+				sessionId,
+				senderId: sessionId,
+				senderType: senderType ?? "participant",
+				content,
+				createdAt: now,
+				...(idempotencyKey && { idempotencyKey }),
+			};
+
+			let insertedId: ObjectId;
+			try {
+				const result = await collection.insertOne(message);
+				insertedId = result.insertedId;
+			} catch (err) {
+				// Handle duplicate key error for idempotency
+				if (err instanceof MongoServerError && err.code === 11000) {
+					const existing = await collection.findOne({ idempotencyKey });
+					if (existing) {
+						return {
+							messageId: existing._id?.toString(),
+							createdAt: existing.createdAt.toISOString(),
+							deduplicated: true,
+						};
+					}
+				}
+				throw err;
+			}
+
+			const messageId = insertedId.toString();
+
+			// Broadcast to all group members
+			const memberIds = await getGroupMembers(groupId);
+			const eventData = {
+				messageId,
+				groupId,
+				sessionId,
+				senderId: sessionId,
+				senderType: senderType ?? "participant",
+				content,
+				createdAt: now.toISOString(),
+			};
+
+			for (const memberId of memberIds) {
+				broadcastToSession(memberId, "chat_message", eventData);
+			}
+
+			return {
+				messageId,
+				createdAt: now.toISOString(),
+			};
+		},
+		{
+			params: t.Object({ groupId: t.String() }),
+			body: t.Object({
+				sessionId: t.String({ minLength: 1 }),
+				content: t.String({ minLength: 1 }),
+				idempotencyKey: t.Optional(t.String()),
+				senderType: t.Optional(
+					t.Union([
+						t.Literal("participant"),
+						t.Literal("agent"),
+						t.Literal("system"),
+					]),
+				),
+			}),
+		},
+	)
+	.get(
+		"/:groupId/history",
+		async ({ params: { groupId }, query, set }) => {
+			const { sessionId } = query;
+
+			// Verify membership
+			const isMember = await verifyMembership(sessionId, groupId);
+			if (!isMember) {
+				set.status = 403;
+				return { error: "not_a_member" };
+			}
+
+			const collection = await getChatMessagesCollection();
+
+			const messages = await collection
+				.find({ groupId })
+				.sort({ createdAt: 1 })
+				.toArray();
+
+			return {
+				messages: messages.map((msg) => ({
+					messageId: msg._id?.toString(),
+					groupId: msg.groupId,
+					sessionId: msg.sessionId,
+					senderId: msg.senderId,
+					senderType: msg.senderType,
+					content: msg.content,
+					createdAt: msg.createdAt.toISOString(),
+				})),
+			};
+		},
+		{
+			params: t.Object({ groupId: t.String() }),
+			query: t.Object({
+				sessionId: t.String({ minLength: 1 }),
+			}),
+		},
+	);

--- a/apps/lab/server/src/types.ts
+++ b/apps/lab/server/src/types.ts
@@ -82,3 +82,14 @@ export type IdempotencyRecord = {
 	key: string;
 	createdAt: Date;
 };
+
+export type ChatMessageDocument = {
+	_id?: import("mongodb").ObjectId;
+	groupId: string;
+	sessionId: string;
+	senderId: string;
+	senderType: "participant" | "agent" | "system";
+	content: string;
+	createdAt: Date;
+	idempotencyKey?: string;
+};


### PR DESCRIPTION
## Summary
- Add ChatMessageDocument type and chat_messages collection with indexes
- Add /chat/:groupId/send and /chat/:groupId/history endpoints with membership verification
- Add SSE client singleton with reconnection logic
- Add ChatView component with markdown rendering and auto-scroll
- Add chat runtime adapter with SSE subscription and deduplication
- Connect SSE on session start in App.tsx

Closes #17

## Test plan
- [x] POST /chat/:groupId/send persists message and returns messageId
- [x] GET /chat/:groupId/history returns messages sorted by createdAt
- [x] SSE broadcasts chat_message events to connected clients
- [x] Idempotency keys prevent duplicate messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)