### PR TITLE
Add AI agent integration with built-in tools

### DIFF
--- a/apps/lab/app/public/configs/ai-chat.json
+++ b/apps/lab/app/public/configs/ai-chat.json
@@ -132,5 +132,35 @@
         }
       ]
     }
+  ],
+  "agents": [
+    {
+      "id": "dealer",
+      "model": "gpt-4o-mini",
+      "system": "You are a used car dealer. The car is a 2019 Honda Civic with 45,000 miles.\nYour reserve price is $12,000 — you will not sell below this.\nYour starting ask is $18,000.\nBe friendly but firm. Use negotiation tactics.\nIf the buyer agrees to a price at or above $12,000, use assign_state to record the agreed price and that a deal was reached, then use end_chat.\n",
+      "tools": [
+        {
+          "name": "end_chat",
+          "description": "End the negotiation. Disables chat and prompts participant to continue."
+        },
+        {
+          "name": "assign_state",
+          "description": "Write a value to the participant's user_state.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "path",
+              "value"
+            ]
+          }
+        }
+      ]
+    }
   ]
 }

--- a/apps/lab/app/public/configs/ai-chat.yaml
+++ b/apps/lab/app/public/configs/ai-chat.yaml
@@ -89,7 +89,7 @@ pages:
 
 agents:
   - id: dealer
-    model: "gpt-4o"
+    model: "gpt-4o-mini"
     system: |
       You are a used car dealer. The car is a 2019 Honda Civic with 45,000 miles.
       Your reserve price is $12,000 — you will not sell below this.

--- a/apps/lab/app/src/components/Chat/ChatView.tsx
+++ b/apps/lab/app/src/components/Chat/ChatView.tsx
@@ -118,22 +118,22 @@ function MessageBubble({ message }: { message: ChatMessage }) {
 	} else if (isOwn) {
 		// Own messages: right-aligned, dark background
 		alignmentClasses = "flex justify-end";
-		bubbleClasses += " bg-slate-900 text-white";
+		bubbleClasses += " bg-slate-700 text-white";
 	} else if (isAgent) {
-		// Agent messages: left-aligned, blue background
+		// Agent messages: left-aligned, light background
 		alignmentClasses = "flex justify-start";
-		bubbleClasses += " bg-blue-500 text-white";
+		bubbleClasses += " bg-slate-100 text-slate-900";
 	} else {
 		// Other participant messages: left-aligned, light background
 		alignmentClasses = "flex justify-start";
-		bubbleClasses += " bg-slate-100 text-slate-900";
+		bubbleClasses += " bg-slate-200 text-slate-900";
 	}
 
 	return (
 		<div className={alignmentClasses}>
 			<div className={bubbleClasses}>
-				<div className="prose prose-sm max-w-none prose-p:my-0 prose-p:leading-relaxed prose-headings:my-1 prose-ul:my-1 prose-ol:my-1 prose-li:my-0 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0">
-					{isOwn || isAgent ? (
+				<div className={`prose prose-sm max-w-none prose-p:my-0 prose-p:leading-relaxed prose-headings:my-1 prose-ul:my-1 prose-ol:my-1 prose-li:my-0 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 ${isOwn ? "prose-invert" : ""}`}>
+					{isOwn ? (
 						<Markdown
 							components={{
 								// Override text color for dark backgrounds

--- a/apps/lab/app/src/lib/sse.ts
+++ b/apps/lab/app/src/lib/sse.ts
@@ -78,6 +78,18 @@ class SSEClient {
 		this.eventSource.addEventListener("user_state_change", (event) => {
 			this.dispatchEvent("user_state_change", JSON.parse(event.data));
 		});
+
+		this.eventSource.addEventListener("chat_ended", (event) => {
+			this.dispatchEvent("chat_ended", JSON.parse(event.data));
+		});
+
+		this.eventSource.addEventListener("state_updated", (event) => {
+			this.dispatchEvent("state_updated", JSON.parse(event.data));
+		});
+
+		this.eventSource.addEventListener("chat_message_delta", (event) => {
+			this.dispatchEvent("chat_message_delta", JSON.parse(event.data));
+		});
 	}
 
 	private handleDisconnect(): void {

--- a/apps/lab/app/vite.config.ts
+++ b/apps/lab/app/vite.config.ts
@@ -27,6 +27,10 @@ export default defineConfig({
 				target: "http://localhost:3001",
 				changeOrigin: true,
 			},
+			"/chat": {
+				target: "http://localhost:3001",
+				changeOrigin: true,
+			},
 		},
 	},
 });

--- a/apps/lab/server/package.json
+++ b/apps/lab/server/package.json
@@ -9,13 +9,15 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@anthropic-ai/sdk": "^0.74.0",
 		"@elysiajs/cors": "^1.1.1",
 		"@elysiajs/static": "^1.4.7",
 		"@pairit/auth": "workspace:*",
 		"@pairit/db": "workspace:*",
 		"better-auth": "^1.0.7",
 		"elysia": "^1.1.25",
-		"mongodb": "^6.12.0"
+		"mongodb": "^6.12.0",
+		"openai": "^6.21.0"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.1.13",

--- a/apps/lab/server/src/lib/agent-runner.ts
+++ b/apps/lab/server/src/lib/agent-runner.ts
@@ -1,0 +1,273 @@
+/**
+ * Agent Runner
+ * Orchestrates AI agent responses to chat messages
+ */
+
+import { getAgentById, getPageAgentIds, getSessionConfig } from "./agents";
+import {
+	getChatMessagesCollection,
+	getEventsCollection,
+	getSessionsCollection,
+} from "./db";
+import type { AgentConfig, ChatMessage } from "./llm";
+import { streamAgentResponse } from "./llm";
+import { broadcastToSession, getConnectionCount } from "./sse";
+
+const AGENT_TIMEOUT_MS = 60_000;
+
+const activeRuns = new Map<string, AbortController>();
+
+export async function triggerAgents(
+	groupId: string,
+	sessionId: string,
+): Promise<void> {
+	if (activeRuns.has(groupId)) {
+		return;
+	}
+
+	const sessionConfig = await getSessionConfig(sessionId);
+	if (!sessionConfig) {
+		return;
+	}
+
+	const { configId, currentPageId } = sessionConfig;
+
+	const agentIds = await getPageAgentIds(configId, currentPageId);
+	if (agentIds.length === 0) {
+		return;
+	}
+
+	for (const agentId of agentIds) {
+		const agent = await getAgentById(configId, agentId);
+		if (!agent) {
+			console.error(`[Agent] Agent not found: ${agentId}`);
+			continue;
+		}
+
+		await runAgent(agent, groupId, sessionId);
+	}
+}
+
+async function runAgent(
+	agent: AgentConfig,
+	groupId: string,
+	sessionId: string,
+): Promise<void> {
+	const abortController = new AbortController();
+	activeRuns.set(groupId, abortController);
+
+	const timeout = setTimeout(() => {
+		console.log(`[Agent] Timeout for group ${groupId}`);
+		abortController.abort();
+	}, AGENT_TIMEOUT_MS);
+
+	try {
+		const history = await loadChatHistory(groupId);
+
+		if (history.length === 0) {
+			return;
+		}
+
+		if (getConnectionCount(sessionId) === 0) {
+			console.log(
+				`[Agent] No SSE connections for session ${sessionId}, skipping`,
+			);
+			return;
+		}
+
+		let fullText = "";
+		const toolCalls: Array<{ name: string; args: Record<string, unknown> }> =
+			[];
+
+		for await (const delta of streamAgentResponse(
+			agent,
+			history,
+			abortController.signal,
+		)) {
+			if (delta.type === "text_delta") {
+				fullText += delta.text;
+			} else if (delta.type === "tool_call") {
+				toolCalls.push({ name: delta.name, args: delta.args });
+			}
+		}
+
+		if (fullText.trim()) {
+			await persistAndBroadcastMessage(
+				groupId,
+				`agent:${agent.id}`,
+				"agent",
+				fullText,
+			);
+		}
+
+		const memberIds = await getGroupMembers(groupId);
+		for (const toolCall of toolCalls) {
+			await handleToolCall(
+				toolCall.name,
+				toolCall.args,
+				groupId,
+				sessionId,
+				memberIds,
+			);
+		}
+	} catch (error) {
+		if ((error as Error).name === "AbortError") {
+			console.log(`[Agent] Run aborted for group ${groupId}`);
+		} else {
+			console.error(`[Agent] Error running agent ${agent.id}:`, error);
+			await persistAndBroadcastMessage(
+				groupId,
+				"system",
+				"system",
+				"Sorry, I encountered an error. Please try again.",
+			);
+		}
+	} finally {
+		clearTimeout(timeout);
+		activeRuns.delete(groupId);
+	}
+}
+
+async function loadChatHistory(groupId: string): Promise<ChatMessage[]> {
+	const collection = await getChatMessagesCollection();
+	const messages = await collection
+		.find({ groupId })
+		.sort({ createdAt: 1 })
+		.toArray();
+
+	return messages.map((msg) => ({
+		role: msg.senderType === "agent" ? "assistant" : "user",
+		content: msg.content,
+	}));
+}
+
+async function persistAndBroadcastMessage(
+	groupId: string,
+	senderId: string,
+	senderType: "participant" | "agent" | "system",
+	content: string,
+): Promise<void> {
+	const collection = await getChatMessagesCollection();
+	const now = new Date();
+
+	const result = await collection.insertOne({
+		groupId,
+		sessionId: senderId,
+		senderId,
+		senderType,
+		content,
+		createdAt: now,
+	});
+
+	const messageId = result.insertedId.toString();
+
+	const memberIds = await getGroupMembers(groupId);
+	const eventData = {
+		messageId,
+		groupId,
+		sessionId: senderId,
+		senderId,
+		senderType,
+		content,
+		createdAt: now.toISOString(),
+	};
+
+	for (const memberId of memberIds) {
+		broadcastToSession(memberId, "chat_message", eventData);
+	}
+}
+
+async function getGroupMembers(groupId: string): Promise<string[]> {
+	const sessionsCollection = await getSessionsCollection();
+	const sessions = await sessionsCollection
+		.find({ "user_state.chat_group_id": groupId })
+		.project({ id: 1 })
+		.toArray();
+
+	const memberIds = sessions.map((s) => s.id);
+
+	if (!memberIds.includes(groupId)) {
+		memberIds.push(groupId);
+	}
+
+	return memberIds;
+}
+
+async function handleToolCall(
+	name: string,
+	args: Record<string, unknown>,
+	groupId: string,
+	sessionId: string,
+	memberIds: string[],
+): Promise<void> {
+	await logToolCallEvent(name, args, sessionId);
+
+	if (name === "end_chat") {
+		console.log(`[Agent] Tool: end_chat for group ${groupId}`);
+		for (const memberId of memberIds) {
+			broadcastToSession(memberId, "chat_ended", { groupId });
+		}
+	}
+
+	if (name === "assign_state") {
+		const { path, value } = args as { path?: string; value?: unknown };
+		if (!path) {
+			console.error("[Agent] assign_state missing path");
+			return;
+		}
+
+		console.log(
+			`[Agent] Tool: assign_state path=${path} value=${JSON.stringify(value)}`,
+		);
+
+		const sessionsCollection = await getSessionsCollection();
+		for (const memberId of memberIds) {
+			if (memberId.startsWith("agent:")) continue;
+
+			await sessionsCollection.updateOne(
+				{ id: memberId },
+				{ $set: { [`user_state.${path}`]: value, updatedAt: new Date() } },
+			);
+
+			broadcastToSession(memberId, "state_updated", { path, value });
+		}
+	}
+}
+
+async function logToolCallEvent(
+	toolName: string,
+	args: Record<string, unknown>,
+	sessionId: string,
+): Promise<void> {
+	try {
+		const collection = await getEventsCollection();
+		await collection.insertOne({
+			type: "agent_tool_call",
+			timestamp: new Date().toISOString(),
+			sessionId,
+			configId: "",
+			pageId: "",
+			componentType: "chat",
+			componentId: "",
+			data: { toolName, args },
+			idempotencyKey: `tool-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+			createdAt: new Date(),
+		});
+	} catch (error) {
+		console.error("[Agent] Failed to log tool call event:", error);
+	}
+}
+
+export function cancelAgentRun(groupId: string): boolean {
+	const controller = activeRuns.get(groupId);
+	if (controller) {
+		controller.abort();
+		activeRuns.delete(groupId);
+		return true;
+	}
+	return false;
+}
+
+export function isAgentRunning(groupId: string): boolean {
+	return activeRuns.has(groupId);
+}

--- a/apps/lab/server/src/lib/agents.ts
+++ b/apps/lab/server/src/lib/agents.ts
@@ -1,0 +1,159 @@
+/**
+ * Agent configuration resolution
+ * Loads agent configs from MongoDB or local files
+ */
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { getConfigsCollection, getSessionsCollection } from "./db";
+import type { AgentConfig } from "./llm";
+
+type RawAgent = {
+	id?: string;
+	model?: string;
+	system?: string;
+	tools?: Array<{
+		name: string;
+		description: string;
+		parameters?: Record<string, unknown>;
+	}>;
+};
+
+function isValidAgent(raw: unknown): raw is RawAgent {
+	if (!raw || typeof raw !== "object") return false;
+	const obj = raw as Record<string, unknown>;
+	return (
+		typeof obj.id === "string" &&
+		typeof obj.model === "string" &&
+		typeof obj.system === "string"
+	);
+}
+
+function toAgentConfig(raw: RawAgent): AgentConfig {
+	return {
+		id: raw.id ?? "",
+		model: raw.model ?? "",
+		system: raw.system ?? "",
+		tools: raw.tools,
+	};
+}
+
+export async function getAgentsForConfig(
+	configId: string,
+): Promise<AgentConfig[]> {
+	const collection = await getConfigsCollection();
+	const doc = await collection.findOne({ configId });
+
+	if (!doc?.config) {
+		return tryLocalConfig(configId);
+	}
+
+	const raw = doc.config as { agents?: unknown[] };
+	const agents = raw?.agents ?? [];
+
+	return agents.filter(isValidAgent).map(toAgentConfig);
+}
+
+async function tryLocalConfig(configId: string): Promise<AgentConfig[]> {
+	try {
+		// Configs are in the lab app's public folder, not the server's cwd
+		const configPath = path.join(
+			process.cwd(),
+			"..",
+			"app",
+			"public",
+			"configs",
+			`${configId}.json`,
+		);
+		const content = await readFile(configPath, "utf8");
+		const parsed = JSON.parse(content) as { agents?: unknown[] };
+		const agents = parsed?.agents ?? [];
+		return agents.filter(isValidAgent).map(toAgentConfig);
+	} catch {
+		return [];
+	}
+}
+
+export async function getAgentById(
+	configId: string,
+	agentId: string,
+): Promise<AgentConfig | null> {
+	const agents = await getAgentsForConfig(configId);
+	return agents.find((a) => a.id === agentId) ?? null;
+}
+
+export async function getSessionConfig(
+	sessionId: string,
+): Promise<{ configId: string; currentPageId: string } | null> {
+	const collection = await getSessionsCollection();
+	const session = await collection.findOne(
+		{ id: sessionId },
+		{ projection: { configId: 1, currentPageId: 1 } },
+	);
+
+	if (!session) return null;
+
+	return {
+		configId: session.configId,
+		currentPageId: session.currentPageId,
+	};
+}
+
+export async function getPageAgentIds(
+	configId: string,
+	pageId: string,
+): Promise<string[]> {
+	const collection = await getConfigsCollection();
+	const doc = await collection.findOne({ configId });
+
+	if (!doc?.config) {
+		return tryLocalPageAgents(configId, pageId);
+	}
+
+	const config = doc.config as {
+		nodes?: Array<{
+			id: string;
+			components?: Array<{ type: string; props?: { agents?: string[] } }>;
+		}>;
+	};
+
+	const page = config.nodes?.find((n) => n.id === pageId);
+	if (!page) {
+		return [];
+	}
+
+	const chatComponent = page.components?.find((c) => c.type === "chat");
+	return (chatComponent?.props?.agents as string[]) ?? [];
+}
+
+async function tryLocalPageAgents(
+	configId: string,
+	pageId: string,
+): Promise<string[]> {
+	try {
+		// Configs are in the lab app's public folder, not the server's cwd
+		const configPath = path.join(
+			process.cwd(),
+			"..",
+			"app",
+			"public",
+			"configs",
+			`${configId}.json`,
+		);
+		const content = await readFile(configPath, "utf8");
+		const parsed = JSON.parse(content) as {
+			nodes?: Array<{
+				id: string;
+				components?: Array<{ type: string; props?: { agents?: string[] } }>;
+			}>;
+		};
+
+		const page = parsed.nodes?.find((n) => n.id === pageId);
+		if (!page) return [];
+
+		const chatComponent = page.components?.find((c) => c.type === "chat");
+		return (chatComponent?.props?.agents as string[]) ?? [];
+	} catch {
+		return [];
+	}
+}

--- a/apps/lab/server/src/lib/llm.ts
+++ b/apps/lab/server/src/lib/llm.ts
@@ -1,0 +1,190 @@
+/**
+ * Unified LLM streaming adapter for OpenAI and Anthropic
+ * Provides a consistent interface for streaming completions
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import OpenAI from "openai";
+
+export type AgentConfig = {
+	id: string;
+	model: string;
+	system: string;
+	tools?: Array<{
+		name: string;
+		description: string;
+		parameters?: Record<string, unknown>;
+	}>;
+};
+
+export type ChatMessage = {
+	role: "user" | "assistant";
+	content: string;
+};
+
+export type StreamDelta =
+	| { type: "text_delta"; text: string }
+	| { type: "tool_call"; name: string; args: Record<string, unknown> }
+	| { type: "done"; fullText: string };
+
+type Provider = "openai" | "anthropic";
+
+function inferProvider(model: string): Provider {
+	if (model.startsWith("claude")) return "anthropic";
+	return "openai";
+}
+
+const openaiClient = new OpenAI({
+	apiKey: process.env.OPENAI_API_KEY,
+});
+
+const anthropicClient = new Anthropic({
+	apiKey: process.env.ANTHROPIC_API_KEY,
+});
+
+export async function* streamAgentResponse(
+	agent: AgentConfig,
+	history: ChatMessage[],
+	signal?: AbortSignal,
+): AsyncGenerator<StreamDelta> {
+	const provider = inferProvider(agent.model);
+
+	if (provider === "anthropic") {
+		yield* streamAnthropic(agent, history, signal);
+	} else {
+		yield* streamOpenAI(agent, history, signal);
+	}
+}
+
+async function* streamOpenAI(
+	agent: AgentConfig,
+	history: ChatMessage[],
+	signal?: AbortSignal,
+): AsyncGenerator<StreamDelta> {
+	const messages: OpenAI.ChatCompletionMessageParam[] = history.map((m) => ({
+		role: m.role,
+		content: m.content,
+	}));
+
+	const tools: OpenAI.ChatCompletionTool[] | undefined = agent.tools?.map(
+		(t) => ({
+			type: "function",
+			function: {
+				name: t.name,
+				description: t.description,
+				parameters: t.parameters ?? { type: "object", properties: {} },
+			},
+		}),
+	);
+
+	const stream = await openaiClient.chat.completions.create(
+		{
+			model: agent.model,
+			messages: [{ role: "system", content: agent.system }, ...messages],
+			stream: true,
+			tools: tools?.length ? tools : undefined,
+		},
+		{ signal },
+	);
+
+	let fullText = "";
+	const toolCalls: Map<number, { name: string; arguments: string }> = new Map();
+
+	for await (const chunk of stream) {
+		const delta = chunk.choices[0]?.delta;
+		if (!delta) continue;
+
+		if (delta.content) {
+			fullText += delta.content;
+			yield { type: "text_delta", text: delta.content };
+		}
+
+		if (delta.tool_calls) {
+			for (const tc of delta.tool_calls) {
+				if (tc.index !== undefined) {
+					let existing = toolCalls.get(tc.index);
+					if (!existing) {
+						existing = { name: "", arguments: "" };
+						toolCalls.set(tc.index, existing);
+					}
+					if (tc.function?.name) {
+						existing.name = tc.function.name;
+					}
+					if (tc.function?.arguments) {
+						existing.arguments += tc.function.arguments;
+					}
+				}
+			}
+		}
+	}
+
+	for (const [, tc] of toolCalls) {
+		if (tc.name) {
+			try {
+				const args = tc.arguments ? JSON.parse(tc.arguments) : {};
+				yield { type: "tool_call", name: tc.name, args };
+			} catch {
+				console.error(`[LLM] Failed to parse tool call args: ${tc.arguments}`);
+			}
+		}
+	}
+
+	yield { type: "done", fullText };
+}
+
+async function* streamAnthropic(
+	agent: AgentConfig,
+	history: ChatMessage[],
+	signal?: AbortSignal,
+): AsyncGenerator<StreamDelta> {
+	const messages: Anthropic.MessageParam[] = history.map((m) => ({
+		role: m.role,
+		content: m.content,
+	}));
+
+	const tools: Anthropic.Tool[] | undefined = agent.tools?.map((t) => ({
+		name: t.name,
+		description: t.description,
+		input_schema: (t.parameters ?? {
+			type: "object",
+			properties: {},
+		}) as Anthropic.Tool.InputSchema,
+	}));
+
+	const streamParams: Anthropic.MessageCreateParams = {
+		model: agent.model,
+		max_tokens: 4096,
+		system: agent.system,
+		messages,
+		...(tools?.length && { tools }),
+	};
+
+	const stream = anthropicClient.messages.stream(streamParams, { signal });
+
+	let fullText = "";
+
+	for await (const event of stream) {
+		if (event.type === "content_block_delta") {
+			const delta = event.delta;
+			if ("text" in delta && delta.text) {
+				fullText += delta.text;
+				yield { type: "text_delta", text: delta.text };
+			}
+		}
+
+		if (event.type === "content_block_stop") {
+			const message = await stream.finalMessage();
+			for (const block of message.content) {
+				if (block.type === "tool_use") {
+					yield {
+						type: "tool_call",
+						name: block.name,
+						args: (block.input as Record<string, unknown>) ?? {},
+					};
+				}
+			}
+		}
+	}
+
+	yield { type: "done", fullText };
+}

--- a/apps/manager/cli/src/index.ts
+++ b/apps/manager/cli/src/index.ts
@@ -19,6 +19,8 @@ type ExperimentConfig = {
 	schema_version?: string;
 	initialPageId?: string;
 	pages?: ExperimentPage[];
+	agents?: unknown[];
+	matchmaking?: unknown;
 };
 
 const program = new Command();
@@ -340,11 +342,17 @@ async function compileConfig(configPath: string): Promise<string> {
 		};
 	});
 
-	const output = {
+	const output: Record<string, unknown> = {
 		schema_version: config.schema_version ?? "v2",
 		initialPageId: config.initialPageId ?? nodes[0]?.id ?? "intro",
 		nodes,
 	};
+	if (config.agents) {
+		output.agents = config.agents;
+	}
+	if (config.matchmaking) {
+		output.matchmaking = config.matchmaking;
+	}
 
 	const resolvedPath = await resolvePath(configPath);
 	const outPath = path.join(

--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,7 @@
       "name": "@pairit/lab-server",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.74.0",
         "@elysiajs/cors": "^1.1.1",
         "@elysiajs/static": "^1.4.7",
         "@pairit/auth": "workspace:*",
@@ -54,6 +55,7 @@
         "better-auth": "^1.0.7",
         "elysia": "^1.1.25",
         "mongodb": "^6.12.0",
+        "openai": "^6.21.0",
       },
       "devDependencies": {
         "@types/bun": "^1.1.13",
@@ -146,6 +148,8 @@
   },
   "packages": {
     "@acemir/cssom": ["@acemir/cssom@0.9.29", "", {}, "sha512-G90x0VW+9nW4dFajtjCoT+NM0scAfH9Mb08IcjgFHYbfiL/lU04dTF9JuVOi3/OH+DJCQdcIseSXkdCB9Ky6JA=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.74.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@4.1.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.4", "@csstools/css-color-parser": "^3.1.0", "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4", "lru-cache": "^11.2.2" } }, "sha512-9xiBAtLn4aNsa4mDnpovJvBn72tNEIACyvlqaNJ+ADemR+yeMJWnBudOi2qGDviJa7SwcDOU/TRh5dnET7qk0w=="],
 
@@ -805,6 +809,8 @@
 
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
 
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
@@ -952,6 +958,8 @@
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
+
+    "openai": ["openai@6.21.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-26dQFi76dB8IiN/WKGQOV+yKKTTlRCxQjoi2WLt0kMcH8pvxVyvfdBDkld5GTl7W1qvBpwVOtFcsqktj3fBRpA=="],
 
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
@@ -1112,6 +1120,8 @@
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 


### PR DESCRIPTION
## Summary

- Add LLM streaming adapter for OpenAI/Anthropic (~100 lines)
- Add agent config resolution from MongoDB/local files
- Add agent runner with 60s timeout and concurrency control
- Implement `end_chat` tool (broadcasts `chat_ended` SSE)
- Implement `assign_state` tool (updates user_state, broadcasts `state_updated`)
- Add `/chat` proxy to Vite config for dev
- Fix CLI to preserve `agents`/`matchmaking` in compiled JSON
- Update Chat component colors for better contrast
- Add `chat_ended`, `state_updated` SSE handlers in frontend

## Test plan

- [x] Start session with ai-chat config
- [x] Navigate to chat page
- [x] Send message, agent responds
- [x] Verify `assign_state` tool updates user_state
- [x] Verify `state_updated` SSE event received

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)