### PR TITLE
Add P0-9 standalone randomization component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,14 @@ packages/
 - **Backend**: Elysia, MongoDB
 - **Auth**: Better Auth with Google OAuth
 
+## Experiment Configs
+
+Configs live in `apps/lab/app/public/configs/`:
+- `.yaml` files are user-facing source configs
+- `.json` files are compiled versions used by the runtime
+
+When updating configs, always update both YAML and JSON to keep them in sync.
+
 ## Conventions
 
 - Package names: `@pairit/{name}`

--- a/apps/lab/app/public/configs/randomization-demo.json
+++ b/apps/lab/app/public/configs/randomization-demo.json
@@ -8,7 +8,42 @@
 				{
 					"type": "text",
 					"props": {
-						"text": "# Randomization Strategies\n\nPairit supports three treatment assignment strategies for experiments:\n\n**1. Random**\nPure random selection. Each group has equal probability of any condition.\nSimple but may result in unbalanced groups, especially with small samples.\n\n**2. Balanced Random**\nAssigns to the condition with fewest groups so far.\nEnsures equal distribution while maintaining unpredictability.\n\n**3. Block**\nRound-robin through conditions: A, B, A, B, A, B...\nDeterministic alternation for strict balance.\n"
+						"text": "# Randomization Demo\n\nThis demo shows how the standalone `randomization` component assigns participants to experimental conditions.\n\nYou will be randomized 5 times to see random assignment in action."
+					}
+				},
+				{
+					"type": "buttons",
+					"props": {
+						"buttons": [
+							{
+								"id": "start",
+								"text": "Start Randomizations",
+								"action": {
+									"type": "go_to",
+									"target": "randomize_1"
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"id": "randomize_1",
+			"components": [
+				{
+					"type": "text",
+					"props": {
+						"text": "## Randomization 1 of 5"
+					}
+				},
+				{
+					"type": "randomization",
+					"props": {
+						"assignmentType": "random",
+						"conditions": ["A", "B"],
+						"stateKey": "condition_1",
+						"showAssignment": true
 					}
 				},
 				{
@@ -17,10 +52,10 @@
 						"buttons": [
 							{
 								"id": "next",
-								"text": "See Examples",
+								"text": "Next",
 								"action": {
 									"type": "go_to",
-									"target": "examples"
+									"target": "randomize_2"
 								}
 							}
 						]
@@ -29,12 +64,21 @@
 			]
 		},
 		{
-			"id": "examples",
+			"id": "randomize_2",
 			"components": [
 				{
 					"type": "text",
 					"props": {
-						"text": "## Configuration Examples\n\nHere's how to configure each strategy in your YAML:\n\n```yaml\nmatchmaking:\n  - id: my_pool\n    num_users: 2\n    timeoutSeconds: 120\n    assignment:\n      type: random  # or balanced_random, or block\n      conditions:\n        - treatment\n        - control\n```\n\nThe assigned condition is stored in `user_state.treatment` and can be used for branching:\n\n```yaml\n- type: buttons\n  props:\n    buttons:\n      - id: continue\n        text: \"Continue\"\n        action:\n          type: go_to\n          branches:\n            - when: \"user_state.treatment == 'treatment'\"\n              target: treatment_page\n            - target: control_page\n```\n"
+						"text": "## Randomization 2 of 5"
+					}
+				},
+				{
+					"type": "randomization",
+					"props": {
+						"assignmentType": "random",
+						"conditions": ["A", "B"],
+						"stateKey": "condition_2",
+						"showAssignment": true
 					}
 				},
 				{
@@ -43,10 +87,10 @@
 						"buttons": [
 							{
 								"id": "next",
-								"text": "When to Use Each",
+								"text": "Next",
 								"action": {
 									"type": "go_to",
-									"target": "when_to_use"
+									"target": "randomize_3"
 								}
 							}
 						]
@@ -55,12 +99,21 @@
 			]
 		},
 		{
-			"id": "when_to_use",
+			"id": "randomize_3",
 			"components": [
 				{
 					"type": "text",
 					"props": {
-						"text": "## When to Use Each Strategy\n\n**Random**\n- Best for: Large samples, simple setup\n- Trade-off: May be unbalanced short-term\n\n**Balanced Random**\n- Best for: Most experiments\n- Trade-off: Slightly predictable near balance point\n\n**Block**\n- Best for: Strict alternation needed\n- Trade-off: Fully predictable sequence\n\n**Recommendation:** Use `balanced_random` for most experiments. It provides the best balance of randomization and equal distribution.\n"
+						"text": "## Randomization 3 of 5"
+					}
+				},
+				{
+					"type": "randomization",
+					"props": {
+						"assignmentType": "random",
+						"conditions": ["A", "B"],
+						"stateKey": "condition_3",
+						"showAssignment": true
 					}
 				},
 				{
@@ -68,11 +121,11 @@
 					"props": {
 						"buttons": [
 							{
-								"id": "explore",
-								"text": "Explore Condition Paths",
+								"id": "next",
+								"text": "Next",
 								"action": {
 									"type": "go_to",
-									"target": "explore"
+									"target": "randomize_4"
 								}
 							}
 						]
@@ -81,12 +134,21 @@
 			]
 		},
 		{
-			"id": "explore",
+			"id": "randomize_4",
 			"components": [
 				{
 					"type": "text",
 					"props": {
-						"text": "## Explore Condition Paths\n\nIn a real experiment, participants would be automatically assigned to one condition.\n\nFor this demo, click below to see what each path looks like:\n"
+						"text": "## Randomization 4 of 5"
+					}
+				},
+				{
+					"type": "randomization",
+					"props": {
+						"assignmentType": "random",
+						"conditions": ["A", "B"],
+						"stateKey": "condition_4",
+						"showAssignment": true
 					}
 				},
 				{
@@ -94,19 +156,11 @@
 					"props": {
 						"buttons": [
 							{
-								"id": "treatment",
-								"text": "See Treatment Path",
+								"id": "next",
+								"text": "Next",
 								"action": {
 									"type": "go_to",
-									"target": "result_treatment"
-								}
-							},
-							{
-								"id": "control",
-								"text": "See Control Path",
-								"action": {
-									"type": "go_to",
-									"target": "result_control"
+									"target": "randomize_5"
 								}
 							}
 						]
@@ -115,28 +169,70 @@
 			]
 		},
 		{
-			"id": "result_treatment",
-			"end": true,
+			"id": "randomize_5",
 			"components": [
 				{
 					"type": "text",
 					"props": {
-						"text": "# Treatment Condition\n\nIn a real experiment, this participant was assigned to **treatment**.\n\nTheir `user_state.treatment` would be set to `\"treatment\"`, and all subsequent branching logic would route them through the treatment experience.\n\nThis assignment is stored in MongoDB and available for data analysis.\n"
+						"text": "## Randomization 5 of 5"
+					}
+				},
+				{
+					"type": "randomization",
+					"props": {
+						"assignmentType": "random",
+						"conditions": ["A", "B"],
+						"stateKey": "condition_5",
+						"showAssignment": true
+					}
+				},
+				{
+					"type": "buttons",
+					"props": {
+						"buttons": [
+							{
+								"id": "next",
+								"text": "See Results",
+								"action": {
+									"type": "go_to",
+									"target": "results"
+								}
+							}
+						]
 					}
 				}
 			]
 		},
 		{
-			"id": "result_control",
-			"end": true,
+			"id": "results",
 			"components": [
 				{
 					"type": "text",
 					"props": {
-						"text": "# Control Condition\n\nIn a real experiment, this participant was assigned to **control**.\n\nTheir `user_state.treatment` would be set to `\"control\"`, and all subsequent branching logic would route them through the control experience.\n\nThis assignment is stored in MongoDB and available for data analysis.\n"
+						"text": "# Results\n\nYou have been assigned to the following conditions:\n\n- **Randomization 1:** {{user_state.condition_1}}\n- **Randomization 2:** {{user_state.condition_2}}\n- **Randomization 3:** {{user_state.condition_3}}\n- **Randomization 4:** {{user_state.condition_4}}\n- **Randomization 5:** {{user_state.condition_5}}\n\nEach randomization is independent with 50/50 probability for A or B."
+					}
+				},
+				{
+					"type": "buttons",
+					"props": {
+						"buttons": [
+							{
+								"id": "finish",
+								"text": "Finish",
+								"action": {
+									"type": "go_to",
+									"target": "end"
+								}
+							}
+						]
 					}
 				}
 			]
+		},
+		{
+			"id": "end",
+			"end": true,
+			"components": []
 		}
 	]
 }

--- a/apps/lab/app/public/configs/randomization-demo.yaml
+++ b/apps/lab/app/public/configs/randomization-demo.yaml
@@ -1,5 +1,5 @@
-# Randomization Demo: Shows 3 assignment strategies
-# Educational walkthrough - no actual matchmaking
+# Randomization Demo: Shows standalone randomization component
+# Demonstrates 5 sequential randomizations
 
 schema_version: 0.1.0
 initialPageId: intro
@@ -10,152 +10,155 @@ pages:
       - type: text
         props:
           text: |
-            # Randomization Strategies
+            # Randomization Demo
 
-            Pairit supports three treatment assignment strategies for experiments:
+            This demo shows how the standalone `randomization` component assigns participants to experimental conditions.
 
-            **1. Random**
-            Pure random selection. Each group has equal probability of any condition.
-            Simple but may result in unbalanced groups, especially with small samples.
+            You will be randomized 5 times to see random assignment in action.
+      - type: buttons
+        props:
+          buttons:
+            - id: start
+              text: "Start Randomizations"
+              action:
+                type: go_to
+                target: randomize_1
 
-            **2. Balanced Random**
-            Assigns to the condition with fewest groups so far.
-            Ensures equal distribution while maintaining unpredictability.
-
-            **3. Block**
-            Round-robin through conditions: A, B, A, B, A, B...
-            Deterministic alternation for strict balance.
+  - id: randomize_1
+    components:
+      - type: text
+        props:
+          text: "## Randomization 1 of 5"
+      - type: randomization
+        props:
+          assignmentType: random
+          conditions:
+            - A
+            - B
+          stateKey: condition_1
+          showAssignment: true
       - type: buttons
         props:
           buttons:
             - id: next
-              text: "See Examples"
+              text: "Next"
               action:
                 type: go_to
-                target: examples
+                target: randomize_2
 
-  - id: examples
+  - id: randomize_2
     components:
       - type: text
         props:
-          text: |
-            ## Configuration Examples
-
-            Here's how to configure each strategy in your YAML:
-
-            ```yaml
-            matchmaking:
-              - id: my_pool
-                num_users: 2
-                timeoutSeconds: 120
-                assignment:
-                  type: random  # or balanced_random, or block
-                  conditions:
-                    - treatment
-                    - control
-            ```
-
-            The assigned condition is stored in `user_state.treatment` and can be used for branching:
-
-            ```yaml
-            - type: buttons
-              props:
-                buttons:
-                  - id: continue
-                    text: "Continue"
-                    action:
-                      type: go_to
-                      branches:
-                        - when: "user_state.treatment == 'treatment'"
-                          target: treatment_page
-                        - target: control_page
-            ```
+          text: "## Randomization 2 of 5"
+      - type: randomization
+        props:
+          assignmentType: random
+          conditions:
+            - A
+            - B
+          stateKey: condition_2
+          showAssignment: true
       - type: buttons
         props:
           buttons:
             - id: next
-              text: "When to Use Each"
+              text: "Next"
               action:
                 type: go_to
-                target: when_to_use
+                target: randomize_3
 
-  - id: when_to_use
+  - id: randomize_3
     components:
       - type: text
         props:
-          text: |
-            ## When to Use Each Strategy
-
-            **Random**
-            - Best for: Large samples, simple setup
-            - Trade-off: May be unbalanced short-term
-
-            **Balanced Random**
-            - Best for: Most experiments
-            - Trade-off: Slightly predictable near balance point
-
-            **Block**
-            - Best for: Strict alternation needed
-            - Trade-off: Fully predictable sequence
-
-            **Recommendation:** Use `balanced_random` for most experiments. It provides the best balance of randomization and equal distribution.
+          text: "## Randomization 3 of 5"
+      - type: randomization
+        props:
+          assignmentType: random
+          conditions:
+            - A
+            - B
+          stateKey: condition_3
+          showAssignment: true
       - type: buttons
         props:
           buttons:
-            - id: explore
-              text: "Explore Condition Paths"
+            - id: next
+              text: "Next"
               action:
                 type: go_to
-                target: explore
+                target: randomize_4
 
-  - id: explore
+  - id: randomize_4
     components:
       - type: text
         props:
-          text: |
-            ## Explore Condition Paths
-
-            In a real experiment, participants would be automatically assigned to one condition.
-
-            For this demo, click below to see what each path looks like:
+          text: "## Randomization 4 of 5"
+      - type: randomization
+        props:
+          assignmentType: random
+          conditions:
+            - A
+            - B
+          stateKey: condition_4
+          showAssignment: true
       - type: buttons
         props:
           buttons:
-            - id: treatment
-              text: "See Treatment Path"
+            - id: next
+              text: "Next"
               action:
                 type: go_to
-                target: result_treatment
-            - id: control
-              text: "See Control Path"
-              action:
-                type: go_to
-                target: result_control
+                target: randomize_5
 
-  - id: result_treatment
-    end: true
+  - id: randomize_5
+    components:
+      - type: text
+        props:
+          text: "## Randomization 5 of 5"
+      - type: randomization
+        props:
+          assignmentType: random
+          conditions:
+            - A
+            - B
+          stateKey: condition_5
+          showAssignment: true
+      - type: buttons
+        props:
+          buttons:
+            - id: next
+              text: "See Results"
+              action:
+                type: go_to
+                target: results
+
+  - id: results
     components:
       - type: text
         props:
           text: |
-            # Treatment Condition
+            # Results
 
-            In a real experiment, this participant was assigned to **treatment**.
+            You have been assigned to the following conditions:
 
-            Their `user_state.treatment` would be set to `"treatment"`, and all subsequent branching logic would route them through the treatment experience.
+            - **Randomization 1:** {{user_state.condition_1}}
+            - **Randomization 2:** {{user_state.condition_2}}
+            - **Randomization 3:** {{user_state.condition_3}}
+            - **Randomization 4:** {{user_state.condition_4}}
+            - **Randomization 5:** {{user_state.condition_5}}
 
-            This assignment is stored in MongoDB and available for data analysis.
-
-  - id: result_control
-    end: true
-    components:
-      - type: text
+            Each randomization is independent with 50/50 probability for A or B.
+      - type: buttons
         props:
-          text: |
-            # Control Condition
+          buttons:
+            - id: finish
+              text: "Finish"
+              action:
+                type: go_to
+                target: end
 
-            In a real experiment, this participant was assigned to **control**.
-
-            Their `user_state.treatment` would be set to `"control"`, and all subsequent branching logic would route them through the control experience.
-
-            This assignment is stored in MongoDB and available for data analysis.
+  - id: end
+    end: true
+    components: []

--- a/apps/lab/app/src/App.tsx
+++ b/apps/lab/app/src/App.tsx
@@ -5,8 +5,8 @@ import { useEffect, useState } from "react";
 import Header from "./components/Header";
 import {
 	AuthRequiredError,
-	type ProlificParams,
 	advance,
+	type ProlificParams,
 	startSession,
 } from "./lib/api";
 import { useSession } from "./lib/auth-client";

--- a/apps/lab/app/src/components/Randomization/RandomizationPanel.tsx
+++ b/apps/lab/app/src/components/Randomization/RandomizationPanel.tsx
@@ -1,0 +1,128 @@
+/**
+ * RandomizationPanel - Presentational component for randomization UI
+ * Shows loading state and assignment result
+ */
+
+export type RandomizationStatus = "loading" | "assigned" | "error";
+
+export type RandomizationPanelProps = {
+	status: RandomizationStatus;
+	condition?: string;
+	showAssignment?: boolean;
+};
+
+export function RandomizationPanel({
+	status,
+	condition,
+	showAssignment = true,
+}: RandomizationPanelProps) {
+	return (
+		<div className="mx-auto flex max-w-md flex-col items-center gap-6 rounded-2xl border border-slate-200 bg-white p-8">
+			{status === "loading" && (
+				<>
+					<div className="flex h-16 w-16 items-center justify-center">
+						<div className="h-8 w-8 animate-spin rounded-full border-4 border-slate-200 border-t-blue-500" />
+					</div>
+					<div className="text-center">
+						<h2 className="text-lg font-semibold text-slate-900">
+							Assigning condition...
+						</h2>
+						<p className="mt-1 text-sm text-slate-500">
+							Please wait while we set up your session
+						</p>
+					</div>
+				</>
+			)}
+
+			{status === "assigned" && showAssignment && condition && (
+				<>
+					<div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+						<svg
+							className="h-8 w-8 text-green-600"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+							aria-hidden="true"
+						>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								strokeWidth={2}
+								d="M5 13l4 4L19 7"
+							/>
+						</svg>
+					</div>
+					<div className="text-center">
+						<h2 className="text-lg font-semibold text-slate-900">
+							Condition assigned
+						</h2>
+						<p className="mt-1 text-sm text-slate-500">
+							You have been assigned to a condition
+						</p>
+					</div>
+					<div className="w-full rounded-lg bg-slate-50 p-3 text-sm">
+						<p className="text-slate-600">
+							<span className="font-medium">Condition:</span> {condition}
+						</p>
+					</div>
+				</>
+			)}
+
+			{status === "assigned" && !showAssignment && (
+				<>
+					<div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+						<svg
+							className="h-8 w-8 text-green-600"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+							aria-hidden="true"
+						>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								strokeWidth={2}
+								d="M5 13l4 4L19 7"
+							/>
+						</svg>
+					</div>
+					<div className="text-center">
+						<h2 className="text-lg font-semibold text-slate-900">
+							Setup complete
+						</h2>
+						<p className="mt-1 text-sm text-slate-500">Continuing...</p>
+					</div>
+				</>
+			)}
+
+			{status === "error" && (
+				<>
+					<div className="flex h-16 w-16 items-center justify-center rounded-full bg-red-100">
+						<svg
+							className="h-8 w-8 text-red-600"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+							aria-hidden="true"
+						>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								strokeWidth={2}
+								d="M6 18L18 6M6 6l12 12"
+							/>
+						</svg>
+					</div>
+					<div className="text-center">
+						<h2 className="text-lg font-semibold text-slate-900">
+							Something went wrong
+						</h2>
+						<p className="mt-1 text-sm text-slate-500">
+							Unable to assign condition
+						</p>
+					</div>
+				</>
+			)}
+		</div>
+	);
+}

--- a/apps/lab/app/src/components/Randomization/runtime.tsx
+++ b/apps/lab/app/src/components/Randomization/runtime.tsx
@@ -1,0 +1,106 @@
+/**
+ * Randomization Runtime - Connects RandomizationPanel to the runtime system
+ * Handles treatment assignment without matchmaking
+ */
+
+import { randomize } from "@app/lib/api";
+import { defineRuntimeComponent } from "@app/runtime/define-runtime-component";
+import { useEffect, useRef, useState } from "react";
+import {
+	RandomizationPanel,
+	type RandomizationStatus,
+} from "./RandomizationPanel";
+
+type RandomizationProps = {
+	assignmentType?: "random" | "balanced_random" | "block";
+	conditions?: string[];
+	stateKey?: string;
+	target?: string;
+	showAssignment?: boolean;
+};
+
+export const RandomizationRuntime = defineRuntimeComponent<
+	"randomization",
+	RandomizationProps
+>({
+	type: "randomization",
+	renderer: ({ component, context }) => {
+		const { sessionId, onAction, onUserStateChange } = context;
+		const [status, setStatus] = useState<RandomizationStatus>("loading");
+		const [condition, setCondition] = useState<string>();
+		const hasCalledRef = useRef(false);
+
+		const assignmentType = component.props.assignmentType ?? "random";
+		const conditions = component.props.conditions ?? [];
+		const stateKey = component.props.stateKey ?? "treatment";
+		const target = component.props.target;
+		const showAssignment = component.props.showAssignment ?? true;
+
+		useEffect(() => {
+			if (!sessionId || hasCalledRef.current) return;
+			hasCalledRef.current = true;
+
+			const currentSessionId = sessionId;
+
+			async function assign() {
+				try {
+					const result = await randomize(currentSessionId, {
+						assignmentType,
+						conditions,
+						stateKey,
+					});
+
+					console.log(
+						`[Randomization] Assigned ${stateKey}: ${result.condition} (existing: ${result.existing})`,
+					);
+
+					setCondition(result.condition);
+					setStatus("assigned");
+
+					// Update local user state
+					if (onUserStateChange) {
+						onUserStateChange({ [stateKey]: result.condition });
+					}
+
+					// Auto-advance to target page if specified
+					if (target) {
+						const delay = showAssignment ? 1500 : 500;
+						setTimeout(() => {
+							onAction({ type: "go_to", target });
+						}, delay);
+					}
+				} catch (error) {
+					console.error("[Randomization] Failed to assign:", error);
+					setStatus("error");
+				}
+			}
+
+			assign();
+		}, [
+			sessionId,
+			assignmentType,
+			conditions,
+			stateKey,
+			target,
+			showAssignment,
+			onAction,
+			onUserStateChange,
+		]);
+
+		if (!sessionId) {
+			return (
+				<div className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+					Randomization requires an active session.
+				</div>
+			);
+		}
+
+		return (
+			<RandomizationPanel
+				status={status}
+				condition={condition}
+				showAssignment={showAssignment}
+			/>
+		);
+	},
+});

--- a/apps/lab/app/src/components/runtime.ts
+++ b/apps/lab/app/src/components/runtime.ts
@@ -5,3 +5,4 @@ import "./Survey/runtime";
 import "./PagedSurvey/runtime";
 import "./Chat/runtime";
 import "./Matchmaking/runtime";
+import "./Randomization/runtime";

--- a/apps/lab/app/src/components/ui/Text/runtime.tsx
+++ b/apps/lab/app/src/components/ui/Text/runtime.tsx
@@ -2,20 +2,35 @@ import { defineRuntimeComponent } from "@app/runtime/define-runtime-component";
 import type { TextComponent } from "@app/runtime/types";
 import Markdown from "react-markdown";
 
+/**
+ * Interpolate template variables like {{user_state.xxx}} with actual values
+ */
+function interpolate(
+	text: string,
+	userState: Record<string, unknown> | undefined,
+): string {
+	return text.replace(/\{\{user_state\.(\w+)\}\}/g, (_, key) => {
+		const value = userState?.[key];
+		return value !== undefined ? String(value) : `{{user_state.${key}}}`;
+	});
+}
+
 export const TextRuntime = defineRuntimeComponent<
 	"text",
 	TextComponent["props"]
 >({
 	type: "text",
-	renderer: ({ component }) => {
+	renderer: ({ component, context }) => {
 		const text = component.props.text;
 		if (!text) {
 			return null;
 		}
 
+		const interpolatedText = interpolate(text, context.userState);
+
 		return (
 			<div className="prose prose-slate max-w-none">
-				<Markdown>{text}</Markdown>
+				<Markdown>{interpolatedText}</Markdown>
 			</div>
 		);
 	},

--- a/apps/lab/app/src/lib/api.ts
+++ b/apps/lab/app/src/lib/api.ts
@@ -212,3 +212,30 @@ export async function cancelMatchmaking(
 	if (!r.ok) throw new Error("Failed to cancel matchmaking");
 	return r.json();
 }
+
+// Randomization API
+
+export type RandomizeParams = {
+	assignmentType?: "random" | "balanced_random" | "block";
+	conditions?: string[];
+	stateKey?: string;
+};
+
+export type RandomizeResponse = {
+	condition: string;
+	existing: boolean;
+};
+
+export async function randomize(
+	sessionId: string,
+	params: RandomizeParams = {},
+): Promise<RandomizeResponse> {
+	const r = await fetch(`${baseUrl}/sessions/${sessionId}/randomize`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		credentials: "include",
+		body: JSON.stringify(params),
+	});
+	if (!r.ok) throw new Error("Failed to randomize");
+	return r.json();
+}

--- a/apps/lab/app/src/routes/Landing.tsx
+++ b/apps/lab/app/src/routes/Landing.tsx
@@ -46,7 +46,6 @@ const sampleConfigs: DemoConfig[] = [
 		title: "Randomization",
 		description: "Random, balanced, and block assignment.",
 		icon: Dices,
-		disabled: true,
 	},
 	{
 		id: "ai-chat",

--- a/apps/lab/app/src/runtime/normalizer.ts
+++ b/apps/lab/app/src/runtime/normalizer.ts
@@ -6,7 +6,11 @@ import type {
 	TextComponent,
 } from "./types";
 
-type RawButton = Partial<Button> & { text?: unknown; action?: unknown; highlightWhen?: unknown };
+type RawButton = Partial<Button> & {
+	text?: unknown;
+	action?: unknown;
+	highlightWhen?: unknown;
+};
 
 type RawComponent =
 	| string

--- a/apps/lab/server/src/index.ts
+++ b/apps/lab/server/src/index.ts
@@ -12,6 +12,7 @@ import { chatRoutes } from "./routes/chat";
 import { configsRoutes } from "./routes/configs";
 import { eventsRoutes } from "./routes/events";
 import { matchmakingRoutes } from "./routes/matchmaking";
+import { randomizeRoutes } from "./routes/randomize";
 import { sessionsRoutes } from "./routes/sessions";
 import { streamRoutes } from "./routes/stream";
 
@@ -88,7 +89,8 @@ app
 	.use(eventsRoutes)
 	.use(streamRoutes)
 	.use(chatRoutes)
-	.use(matchmakingRoutes);
+	.use(matchmakingRoutes)
+	.use(randomizeRoutes);
 
 // Static file serving (production only - in dev, Vite handles this)
 if (!IS_DEV) {

--- a/apps/lab/server/src/lib/treatment-assignment.ts
+++ b/apps/lab/server/src/lib/treatment-assignment.ts
@@ -1,0 +1,72 @@
+/**
+ * Treatment Assignment Module
+ * Shared logic for assigning participants to experimental conditions
+ */
+
+export type AssignmentType = "random" | "balanced_random" | "block";
+
+// Track condition counts per balance key for balanced_random
+const conditionCounts = new Map<string, Map<string, number>>();
+
+// Track block position per balance key for block randomization
+const blockPositions = new Map<string, number>();
+
+/**
+ * Assign treatment based on assignment strategy
+ * @param balanceKey - Key to track balance across (e.g., configId or poolKey)
+ * @param conditions - Array of condition names (defaults to ["control", "treatment"])
+ * @param assignmentType - Strategy: "random", "balanced_random", or "block"
+ */
+export function assignTreatment(
+	balanceKey: string,
+	conditions: string[],
+	assignmentType: AssignmentType = "random",
+): string {
+	const opts = conditions.length ? conditions : ["control", "treatment"];
+
+	if (assignmentType === "random") {
+		return opts[Math.floor(Math.random() * opts.length)];
+	}
+
+	if (assignmentType === "balanced_random") {
+		// Pick condition with lowest count
+		let counts = conditionCounts.get(balanceKey);
+		if (!counts) {
+			counts = new Map(opts.map((c) => [c, 0]));
+			conditionCounts.set(balanceKey, counts);
+		}
+		const minCount = Math.min(...opts.map((c) => counts.get(c) ?? 0));
+		const candidates = opts.filter((c) => (counts.get(c) ?? 0) === minCount);
+		const chosen = candidates[Math.floor(Math.random() * candidates.length)];
+		counts.set(chosen, (counts.get(chosen) ?? 0) + 1);
+		return chosen;
+	}
+
+	if (assignmentType === "block") {
+		// Round-robin through conditions in order
+		const pos = blockPositions.get(balanceKey) ?? 0;
+		const chosen = opts[pos % opts.length];
+		blockPositions.set(balanceKey, pos + 1);
+		return chosen;
+	}
+
+	return opts[0];
+}
+
+/**
+ * Get current condition counts for a balance key (for debugging)
+ */
+export function getConditionCounts(
+	balanceKey: string,
+): Record<string, number> | null {
+	const counts = conditionCounts.get(balanceKey);
+	if (!counts) return null;
+	return Object.fromEntries(counts);
+}
+
+/**
+ * Get current block position for a balance key (for debugging)
+ */
+export function getBlockPosition(balanceKey: string): number | null {
+	return blockPositions.get(balanceKey) ?? null;
+}

--- a/apps/lab/server/src/routes/randomize.ts
+++ b/apps/lab/server/src/routes/randomize.ts
@@ -1,0 +1,71 @@
+/**
+ * Randomization Routes
+ * POST /sessions/:id/randomize - Assign treatment without matchmaking
+ */
+
+import { Elysia, t } from "elysia";
+import { getSessionsCollection } from "../lib/db";
+import { assignTreatment } from "../lib/treatment-assignment";
+import { loadSession } from "./sessions";
+
+export const randomizeRoutes = new Elysia({ prefix: "/sessions" }).post(
+	"/:id/randomize",
+	async ({ params: { id }, body, set }) => {
+		// Verify session exists
+		const session = await loadSession(id);
+		if (!session) {
+			set.status = 404;
+			return { error: "session_not_found" };
+		}
+
+		const { assignmentType = "random", conditions = [], stateKey = "treatment" } = body;
+
+		// Idempotent: return existing assignment if present
+		const existingValue = session.user_state?.[stateKey];
+		if (existingValue) {
+			return {
+				condition: existingValue as string,
+				existing: true,
+			};
+		}
+
+		// Use configId + stateKey as balance key (allows separate balance per key)
+		const balanceKey = `${session.configId}:${stateKey}`;
+		const treatment = assignTreatment(balanceKey, conditions, assignmentType);
+
+		// Persist treatment to session
+		const sessionsCollection = await getSessionsCollection();
+		await sessionsCollection.updateOne(
+			{ id },
+			{
+				$set: {
+					[`user_state.${stateKey}`]: treatment,
+					updatedAt: new Date(),
+				},
+			},
+		);
+
+		console.log(
+			`[Randomize] Session ${id} assigned ${stateKey}: ${treatment} (strategy: ${assignmentType})`,
+		);
+
+		return {
+			condition: treatment,
+			existing: false,
+		};
+	},
+	{
+		params: t.Object({ id: t.String() }),
+		body: t.Object({
+			assignmentType: t.Optional(
+				t.Union([
+					t.Literal("random"),
+					t.Literal("balanced_random"),
+					t.Literal("block"),
+				]),
+			),
+			conditions: t.Optional(t.Array(t.String())),
+			stateKey: t.Optional(t.String()),
+		}),
+	},
+);

--- a/apps/lab/server/src/routes/sessions.ts
+++ b/apps/lab/server/src/routes/sessions.ts
@@ -11,6 +11,7 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { Elysia, t } from "elysia";
 import { MongoServerError } from "mongodb";
+import { deriveAuthContext } from "../lib/auth-middleware";
 import {
 	getConfigsCollection,
 	getIdempotencyCollection,
@@ -22,8 +23,6 @@ import type {
 	Session,
 	SessionDocument,
 } from "../types";
-
-import { deriveAuthContext } from "../lib/auth-middleware";
 
 const IS_DEV = process.env.NODE_ENV === "development";
 const FORCE_AUTH = process.env.FORCE_AUTH === "true";


### PR DESCRIPTION
## Summary
- Adds standalone `randomization` component for assigning participants to conditions without matchmaking
- Extracts shared treatment assignment logic into reusable module
- Supports `random`, `balanced_random`, and `block` assignment strategies
- Adds template interpolation `{{user_state.xxx}}` to Text component

## Test plan
- [x] Run `bun run dev` and open http://localhost:3000/randomization-demo
- [x] Verify 5 randomizations work with manual "Next" buttons
- [x] Verify results page shows assigned conditions
- [x] Type checks pass: `bunx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)