### PR TITLE
Add back-to-samples button and Prolific completion CTA

### DIFF
--- a/apps/lab/app/public/configs/component-events-showcase.json
+++ b/apps/lab/app/public/configs/component-events-showcase.json
@@ -340,6 +340,7 @@
 		{
 			"id": "outro",
 			"end": true,
+			"endRedirectUrl": "https://app.prolific.com/submissions/complete?cc=EVENTS123",
 			"text": "Thank you for exploring the component events showcase! All your interactions have been recorded as events for analysis.",
 			"buttons": [
 				{

--- a/apps/lab/app/public/configs/component-events-showcase.yaml
+++ b/apps/lab/app/public/configs/component-events-showcase.yaml
@@ -224,6 +224,7 @@ pages:
 
   - id: outro
     end: true
+    endRedirectUrl: "https://app.prolific.com/submissions/complete?cc=EVENTS123"
     text: "Thank you for exploring the component events showcase! All your interactions have been recorded as events for analysis."
     buttons:
       - id: restart

--- a/apps/lab/app/public/configs/hello-world.json
+++ b/apps/lab/app/public/configs/hello-world.json
@@ -37,6 +37,7 @@
 		{
 			"id": "thanks",
 			"end": true,
+			"endRedirectUrl": "https://app.prolific.com/submissions/complete?cc=HELLO123",
 			"components": [
 				{
 					"type": "text",

--- a/apps/lab/app/public/configs/hello-world.yaml
+++ b/apps/lab/app/public/configs/hello-world.yaml
@@ -21,6 +21,7 @@ pages:
 
   - id: thanks
     end: true
+    endRedirectUrl: "https://app.prolific.com/submissions/complete?cc=HELLO123"
     components:
       - type: text
         props:

--- a/apps/lab/app/public/configs/randomization-demo.json
+++ b/apps/lab/app/public/configs/randomization-demo.json
@@ -232,6 +232,7 @@
 		{
 			"id": "end",
 			"end": true,
+			"endRedirectUrl": "https://app.prolific.com/submissions/complete?cc=RAND123",
 			"components": []
 		}
 	]

--- a/apps/lab/app/public/configs/randomization-demo.yaml
+++ b/apps/lab/app/public/configs/randomization-demo.yaml
@@ -161,4 +161,5 @@ pages:
 
   - id: end
     end: true
+    endRedirectUrl: "https://app.prolific.com/submissions/complete?cc=RAND123"
     components: []

--- a/apps/lab/app/public/configs/simple-survey.json
+++ b/apps/lab/app/public/configs/simple-survey.json
@@ -132,6 +132,7 @@
 		{
 			"id": "outro",
 			"end": true,
+			"endRedirectUrl": "https://app.prolific.com/submissions/complete?cc=SURVEY123",
 			"components": [
 				{
 					"type": "text",

--- a/apps/lab/app/public/configs/simple-survey.yaml
+++ b/apps/lab/app/public/configs/simple-survey.yaml
@@ -79,6 +79,7 @@ pages:
 
   - id: outro
     end: true
+    endRedirectUrl: "https://app.prolific.com/submissions/complete?cc=SURVEY123"
     components:
       - type: text
         props:

--- a/apps/lab/app/public/configs/survey-showcase.json
+++ b/apps/lab/app/public/configs/survey-showcase.json
@@ -271,12 +271,14 @@
 		{
 			"id": "disqualified",
 			"text": "Thanks for your interest. You must be 18 or older to participate.",
-			"end": true
+			"end": true,
+			"endRedirectUrl": "https://app.prolific.com/submissions/complete?cc=DISQUAL"
 		},
 		{
 			"id": "outro",
 			"text": "You're all set! We'll tailor your session based on these inputs.\nLook for a message from the research team soon.\n",
-			"end": true
+			"end": true,
+			"endRedirectUrl": "https://app.prolific.com/submissions/complete?cc=SHOWCASE123"
 		}
 	]
 }

--- a/apps/lab/app/public/configs/survey-showcase.yaml
+++ b/apps/lab/app/public/configs/survey-showcase.yaml
@@ -176,9 +176,11 @@ pages:
   - id: disqualified
     text: "Thanks for your interest. You must be 18 or older to participate."
     end: true
+    endRedirectUrl: "https://app.prolific.com/submissions/complete?cc=DISQUAL"
 
   - id: outro
     text: |
       You're all set! We'll tailor your session based on these inputs.
       Look for a message from the research team soon.
     end: true
+    endRedirectUrl: "https://app.prolific.com/submissions/complete?cc=SHOWCASE123"

--- a/apps/lab/app/src/App.tsx
+++ b/apps/lab/app/src/App.tsx
@@ -329,16 +329,28 @@ export default function App() {
 							<>
 								<div className="text-lg font-medium">Thanks, that's it.</div>
 								<div className="text-sm text-slate-500">
-									Continue to the next step below.
+									{endRedirectUrl.toLowerCase().includes("prolific")
+										? "Click below to complete on Prolific."
+										: "Continue to the next step below."}
 								</div>
-								<div className="flex justify-center">
+								<div className="flex justify-center gap-3">
+									<Button
+										variant="ghost"
+										onClick={() => {
+											window.location.href = "/";
+										}}
+									>
+										Back to samples
+									</Button>
 									<Button
 										onClick={() => {
 											if (!endRedirectUrl) return;
 											window.location.assign(endRedirectUrl);
 										}}
 									>
-										Continue
+										{endRedirectUrl.toLowerCase().includes("prolific")
+											? "Continue to Prolific"
+											: "Continue"}
 									</Button>
 								</div>
 							</>
@@ -347,6 +359,16 @@ export default function App() {
 								<div className="text-lg font-medium">Thanks, that's it.</div>
 								<div className="text-sm text-slate-500">
 									You can close this window.
+								</div>
+								<div className="flex justify-center">
+									<Button
+										variant="ghost"
+										onClick={() => {
+											window.location.href = "/";
+										}}
+									>
+										Back to samples
+									</Button>
 								</div>
 							</>
 						)}


### PR DESCRIPTION
## Summary
- Add "Back to samples" button on completion screen (next to the continue button)
- Change completion button to "Continue to Prolific" when redirect URL contains "prolific"
- Add Prolific redirect URLs to sample configs missing them

## Test plan
- [x] Open any sample config (e.g., `/hello-world`)
- [x] Complete the flow to reach the completion screen
- [x] Verify "Back to samples" button appears and works
- [x] Verify "Continue to Prolific" button text appears

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)