### PR TITLE
Add profile icons for chat participants

### DIFF
--- a/apps/lab/app/src/components/Chat/ChatView.tsx
+++ b/apps/lab/app/src/components/Chat/ChatView.tsx
@@ -5,6 +5,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import Markdown from "react-markdown";
+import { ParticipantIcon } from "./ParticipantIcon";
 
 export type ChatMessage = {
 	messageId: string;
@@ -118,7 +119,7 @@ function MessageBubble({ message }: { message: ChatMessage }) {
 
 	// Determine bubble styling
 	let bubbleClasses = "max-w-[80%] rounded-2xl px-4 py-2 text-sm";
-	let alignmentClasses = "flex";
+	let alignmentClasses = "flex items-start gap-2";
 
 	if (isSystem) {
 		// System messages: centered, muted
@@ -127,20 +128,27 @@ function MessageBubble({ message }: { message: ChatMessage }) {
 			"rounded-lg bg-slate-100 px-3 py-1.5 text-xs text-slate-500 italic";
 	} else if (isOwn) {
 		// Own messages: right-aligned, dark background
-		alignmentClasses = "flex justify-end";
+		alignmentClasses = "flex items-start justify-end gap-2";
 		bubbleClasses += " bg-slate-700 text-white";
 	} else if (isAgent) {
 		// Agent messages: left-aligned, light background
-		alignmentClasses = "flex justify-start";
+		alignmentClasses = "flex items-start justify-start gap-2";
 		bubbleClasses += " bg-slate-100 text-slate-900";
 	} else {
 		// Other participant messages: left-aligned, light background
-		alignmentClasses = "flex justify-start";
+		alignmentClasses = "flex items-start justify-start gap-2";
 		bubbleClasses += " bg-slate-200 text-slate-900";
 	}
 
 	return (
 		<div className={alignmentClasses}>
+			{!isSystem && !isOwn && (
+				<ParticipantIcon
+					senderId={message.senderId}
+					senderType={message.senderType}
+					isOwn={false}
+				/>
+			)}
 			<div className={bubbleClasses}>
 				<div
 					className={`prose prose-sm max-w-none prose-p:my-0 prose-p:leading-relaxed prose-headings:my-1 prose-ul:my-1 prose-ol:my-1 prose-li:my-0 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 ${isOwn ? "prose-invert" : ""}`}
@@ -174,13 +182,25 @@ function MessageBubble({ message }: { message: ChatMessage }) {
 					)}
 				</div>
 			</div>
+			{!isSystem && isOwn && (
+				<ParticipantIcon
+					senderId={message.senderId}
+					senderType={message.senderType}
+					isOwn={true}
+				/>
+			)}
 		</div>
 	);
 }
 
 function StreamingBubble({ message }: { message: StreamingMessage }) {
 	return (
-		<div className="flex justify-start">
+		<div className="flex items-start justify-start gap-2">
+			<ParticipantIcon
+				senderId={message.senderId}
+				senderType={message.senderType}
+				isOwn={false}
+			/>
 			<div className="max-w-[80%] rounded-2xl bg-slate-100 px-4 py-2 text-sm text-slate-900">
 				<div className="prose prose-sm max-w-none prose-p:my-0 prose-p:leading-relaxed prose-headings:my-1 prose-ul:my-1 prose-ol:my-1 prose-li:my-0 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0">
 					{message.content ? (

--- a/apps/lab/app/src/components/Chat/ParticipantIcon.tsx
+++ b/apps/lab/app/src/components/Chat/ParticipantIcon.tsx
@@ -1,0 +1,40 @@
+/**
+ * ParticipantIcon - Displays an icon for a chat participant
+ */
+
+import { getChatIcon } from "@app/lib/participant-icons";
+
+type ParticipantIconProps = {
+	senderId: string;
+	senderType: "participant" | "agent" | "system";
+	isOwn: boolean;
+	size?: number;
+	className?: string;
+};
+
+export function ParticipantIcon({
+	senderId,
+	senderType,
+	isOwn,
+	size = 20,
+	className = "",
+}: ParticipantIconProps) {
+	const Icon = getChatIcon(senderId, senderType, isOwn);
+
+	if (!Icon) {
+		return null;
+	}
+
+	// Own messages get dark background to match bubble
+	const bgClass = isOwn ? "bg-slate-700" : "bg-slate-100";
+	const iconClass = isOwn ? "text-white" : "text-slate-600";
+
+	return (
+		<div
+			className={`flex shrink-0 items-center justify-center rounded-full ${bgClass} ${className}`}
+			style={{ width: size + 8, height: size + 8 }}
+		>
+			<Icon size={size} className={iconClass} />
+		</div>
+	);
+}

--- a/apps/lab/app/src/lib/participant-icons.ts
+++ b/apps/lab/app/src/lib/participant-icons.ts
@@ -1,0 +1,79 @@
+/**
+ * Participant icon utilities for chat
+ * Provides deterministic icon assignment based on senderId
+ */
+
+import type { LucideIcon } from "lucide-react";
+import {
+	Bot,
+	Cloud,
+	Clover,
+	Flower,
+	Leaf,
+	Moon,
+	Mountain,
+	Sprout,
+	Sun,
+	TreePine,
+	User,
+} from "lucide-react";
+
+// Icon pool for other participants (Nature category)
+const PARTICIPANT_ICONS: LucideIcon[] = [
+	Flower,
+	Leaf,
+	TreePine,
+	Clover,
+	Sprout,
+	Mountain,
+	Cloud,
+	Sun,
+	Moon,
+];
+
+// Fixed icons
+export const SELF_ICON = User;
+export const AGENT_ICON = Bot;
+
+/**
+ * Simple hash function for strings
+ * Returns a number that can be used as an index
+ */
+function hashString(str: string): number {
+	let hash = 0;
+	for (let i = 0; i < str.length; i++) {
+		const char = str.charCodeAt(i);
+		hash = (hash << 5) - hash + char;
+		hash = hash & hash; // Convert to 32-bit integer
+	}
+	return Math.abs(hash);
+}
+
+/**
+ * Get a deterministic icon for a participant based on their senderId
+ * Same senderId always returns the same icon
+ */
+export function getParticipantIcon(senderId: string): LucideIcon {
+	const index = hashString(senderId) % PARTICIPANT_ICONS.length;
+	return PARTICIPANT_ICONS[index];
+}
+
+/**
+ * Get the appropriate icon for a chat message sender
+ */
+export function getChatIcon(
+	senderId: string,
+	senderType: "participant" | "agent" | "system",
+	isOwn: boolean,
+): LucideIcon | null {
+	if (senderType === "system") {
+		return null; // No icon for system messages
+	}
+	if (isOwn) {
+		return SELF_ICON;
+	}
+	if (senderType === "agent") {
+		return AGENT_ICON;
+	}
+	return getParticipantIcon(senderId);
+}


### PR DESCRIPTION
## Summary

- Add Lucide icons next to chat messages to distinguish participants
- Focal participant: User icon (dark background) on right
- AI agents: Bot icon on left
- Other participants: Deterministic icon from Nature pool (Flower, Leaf, TreePine, etc.)

## Test plan

- [x] Open `/ai-chat` and verify Bot icon appears next to agent messages
- [x] Verify User icon appears next to own messages with matching dark style
- [x] Icons align with top of message bubbles

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)