### PR TITLE
P0-9: Data export CLI

### DIFF
--- a/apps/lab/app/public/configs/simple-survey.json
+++ b/apps/lab/app/public/configs/simple-survey.json
@@ -1,146 +1,146 @@
 {
-	"schema_version": "0.1.0",
-	"initialPageId": "intro",
-	"nodes": [
-		{
-			"id": "intro",
-			"components": [
-				{
-					"type": "text",
-					"props": {
-						"text": "Welcome to the paged survey demo.\nThis walk-through shows how a single component can manage multi-step surveys.\n"
-					}
-				},
-				{
-					"type": "buttons",
-					"props": {
-						"buttons": [
-							{
-								"id": "intro_start",
-								"text": "Start",
-								"action": {
-									"type": "go_to",
-									"target": "survey_flow"
-								}
-							}
-						]
-					}
-				}
-			]
-		},
-		{
-			"id": "survey_flow",
-			"components": [
-				{
-					"type": "text",
-					"props": {
-						"text": "Work through each section below. Your progress saves as you go."
-					}
-				},
-				{
-					"type": "paged_survey",
-					"id": "onboarding_flow",
-					"props": {
-						"initialPageId": "basics",
-						"completeAction": {
-							"type": "go_to",
-							"target": "outro"
-						},
-						"pages": [
-							{
-								"id": "basics",
-								"survey": {
-									"title": "Profile basics",
-									"items": [
-										{
-											"id": "preferred_name",
-											"text": "What name should we use?",
-											"answer": "text"
-										},
-										{
-											"id": "timezone",
-											"text": "Which time zone are you working from?",
-											"answer": "text"
-										}
-									]
-								}
-							},
-							{
-								"id": "collaboration",
-								"survey": {
-									"title": "Collaboration preferences",
-									"items": [
-										{
-											"id": "collaboration_style",
-											"text": "Which collaboration style fits you best?",
-											"answer": {
-												"multiple_choice": {
-													"choices": [
-														"Async first",
-														"Hybrid schedule",
-														"Mostly synchronous"
-													]
-												}
-											}
-										},
-										{
-											"id": "meetings_per_week",
-											"text": "Roughly how many meetings per week feel productive?",
-											"answer": {
-												"numeric": {
-													"min": 0,
-													"max": 40,
-													"step": 1
-												}
-											}
-										}
-									]
-								}
-							},
-							{
-								"id": "wrap_up",
-								"survey": {
-									"title": "Final touches",
-									"items": [
-										{
-											"id": "focus_topics",
-											"text": "Select any topics you'd like us to focus on.",
-											"answer": {
-												"multi_select": {
-													"choices": [
-														"Onboarding",
-														"Feedback loops",
-														"Process automation",
-														"Culture & rituals"
-													]
-												}
-											}
-										},
-										{
-											"id": "final_note",
-											"text": "Anything else we should know?",
-											"answer": "free_text"
-										}
-									]
-								}
-							}
-						]
-					}
-				}
-			]
-		},
-		{
-			"id": "outro",
-			"end": true,
-			"endRedirectUrl": "https://app.prolific.com/submissions/complete?cc=SURVEY123",
-			"components": [
-				{
-					"type": "text",
-					"props": {
-						"text": "All set! Thanks for completing the paged survey."
-					}
-				}
-			]
-		}
-	]
+  "schema_version": "0.1.0",
+  "initialPageId": "intro",
+  "nodes": [
+    {
+      "id": "intro",
+      "components": [
+        {
+          "type": "text",
+          "props": {
+            "text": "Welcome to the paged survey demo.\nThis walk-through shows how a single component can manage multi-step surveys.\n"
+          }
+        },
+        {
+          "type": "buttons",
+          "props": {
+            "buttons": [
+              {
+                "id": "intro_start",
+                "text": "Start",
+                "action": {
+                  "type": "go_to",
+                  "target": "survey_flow"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "survey_flow",
+      "components": [
+        {
+          "type": "text",
+          "props": {
+            "text": "Work through each section below. Your progress saves as you go."
+          }
+        },
+        {
+          "type": "paged_survey",
+          "id": "onboarding_flow",
+          "props": {
+            "initialPageId": "basics",
+            "completeAction": {
+              "type": "go_to",
+              "target": "outro"
+            },
+            "pages": [
+              {
+                "id": "basics",
+                "survey": {
+                  "title": "Profile basics",
+                  "items": [
+                    {
+                      "id": "preferred_name",
+                      "text": "What name should we use?",
+                      "answer": "text"
+                    },
+                    {
+                      "id": "timezone",
+                      "text": "Which time zone are you working from?",
+                      "answer": "text"
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "collaboration",
+                "survey": {
+                  "title": "Collaboration preferences",
+                  "items": [
+                    {
+                      "id": "collaboration_style",
+                      "text": "Which collaboration style fits you best?",
+                      "answer": {
+                        "multiple_choice": {
+                          "choices": [
+                            "Async first",
+                            "Hybrid schedule",
+                            "Mostly synchronous"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "id": "meetings_per_week",
+                      "text": "Roughly how many meetings per week feel productive?",
+                      "answer": {
+                        "numeric": {
+                          "min": 0,
+                          "max": 40,
+                          "step": 1
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "wrap_up",
+                "survey": {
+                  "title": "Final touches",
+                  "items": [
+                    {
+                      "id": "focus_topics",
+                      "text": "Select any topics you'd like us to focus on.",
+                      "answer": {
+                        "multi_select": {
+                          "choices": [
+                            "Onboarding",
+                            "Feedback loops",
+                            "Process automation",
+                            "Culture & rituals"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "id": "final_note",
+                      "text": "Anything else we should know?",
+                      "answer": "free_text"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "outro",
+      "end": true,
+      "endRedirectUrl": "https://app.prolific.com/submissions/complete?cc=SURVEY123",
+      "components": [
+        {
+          "type": "text",
+          "props": {
+            "text": "All set! Thanks for completing the paged survey."
+          }
+        }
+      ]
+    }
+  ]
 }

--- a/apps/manager/cli/package.json
+++ b/apps/manager/cli/package.json
@@ -4,7 +4,7 @@
 	"description": "Pairit experiment configuration CLI",
 	"type": "module",
 	"bin": {
-		"pairit": "src/index.ts"
+		"pairit": "dist/index.js"
 	},
 	"scripts": {
 		"build": "bun build src/index.ts --outdir dist --target node",

--- a/apps/manager/server/src/index.ts
+++ b/apps/manager/server/src/index.ts
@@ -9,6 +9,7 @@ import { auth } from "@pairit/auth";
 import { renderPage } from "@pairit/html";
 import { Elysia, t } from "elysia";
 import { configsRoutes } from "./routes/configs";
+import { dataRoutes } from "./routes/data";
 import { mediaRoutes } from "./routes/media";
 
 const IS_DEV = process.env.NODE_ENV === "development";
@@ -361,6 +362,7 @@ app
 		);
 	})
 	.use(configsRoutes)
+	.use(dataRoutes)
 	.use(mediaRoutes)
 	.listen(Number(process.env.PORT) || 3002);
 

--- a/apps/manager/server/src/lib/db.ts
+++ b/apps/manager/server/src/lib/db.ts
@@ -5,7 +5,12 @@
 
 import { connectDB } from "@pairit/db";
 import type { Collection } from "mongodb";
-import type { ConfigDocument } from "../types";
+import type {
+	ChatMessageDocument,
+	ConfigDocument,
+	EventDocument,
+	SessionDocument,
+} from "../types";
 
 export { closeDB, connectDB } from "@pairit/db";
 
@@ -14,4 +19,25 @@ export async function getConfigsCollection(): Promise<
 > {
 	const database = await connectDB();
 	return database.collection<ConfigDocument>("configs");
+}
+
+export async function getSessionsCollection(): Promise<
+	Collection<SessionDocument>
+> {
+	const database = await connectDB();
+	return database.collection<SessionDocument>("sessions");
+}
+
+export async function getEventsCollection(): Promise<
+	Collection<EventDocument>
+> {
+	const database = await connectDB();
+	return database.collection<EventDocument>("events");
+}
+
+export async function getChatMessagesCollection(): Promise<
+	Collection<ChatMessageDocument>
+> {
+	const database = await connectDB();
+	return database.collection<ChatMessageDocument>("chat_messages");
 }

--- a/apps/manager/server/src/routes/data.ts
+++ b/apps/manager/server/src/routes/data.ts
@@ -1,0 +1,185 @@
+/**
+ * Data export routes for manager server
+ * GET /data/:configId/sessions - Export sessions for a config
+ * GET /data/:configId/events - Export events for a config
+ * GET /data/:configId/chat-messages - Export chat messages for a config
+ */
+import { Elysia, t } from "elysia";
+import { authMiddleware } from "../lib/auth-middleware";
+import {
+	getChatMessagesCollection,
+	getConfigsCollection,
+	getEventsCollection,
+	getSessionsCollection,
+} from "../lib/db";
+
+export const dataRoutes = new Elysia({ prefix: "/data" })
+	.use(authMiddleware)
+	.get(
+		"/:configId/sessions",
+		async ({ params: { configId }, set, user }) => {
+			if (!user) {
+				set.status = 401;
+				return { error: "unauthorized", message: "Not authenticated" };
+			}
+
+			// Verify ownership
+			const configsCollection = await getConfigsCollection();
+			const config = await configsCollection.findOne({ configId });
+			if (!config) {
+				set.status = 404;
+				return { error: "not_found", message: "Config not found" };
+			}
+			if (config.owner !== user.id) {
+				set.status = 403;
+				return {
+					error: "forbidden",
+					message: "Not authorized to export this config's data",
+				};
+			}
+
+			const sessionsCollection = await getSessionsCollection();
+			const sessions = await sessionsCollection
+				.find({ configId })
+				.sort({ createdAt: 1 })
+				.toArray();
+
+			const exportData = sessions.map((session) => ({
+				sessionId: session.id,
+				configId: session.configId,
+				currentPageId: session.currentPageId,
+				status: session.endedAt ? "completed" : "in_progress",
+				user_state: session.user_state ?? {},
+				prolific: session.prolific ?? null,
+				userId: session.userId ?? null,
+				createdAt: session.createdAt?.toISOString() ?? null,
+				updatedAt: session.updatedAt?.toISOString() ?? null,
+				endedAt: session.endedAt ?? null,
+			}));
+
+			return { sessions: exportData };
+		},
+		{
+			params: t.Object({
+				configId: t.String(),
+			}),
+		},
+	)
+	.get(
+		"/:configId/events",
+		async ({ params: { configId }, set, user }) => {
+			if (!user) {
+				set.status = 401;
+				return { error: "unauthorized", message: "Not authenticated" };
+			}
+
+			// Verify ownership
+			const configsCollection = await getConfigsCollection();
+			const config = await configsCollection.findOne({ configId });
+			if (!config) {
+				set.status = 404;
+				return { error: "not_found", message: "Config not found" };
+			}
+			if (config.owner !== user.id) {
+				set.status = 403;
+				return {
+					error: "forbidden",
+					message: "Not authorized to export this config's data",
+				};
+			}
+
+			const eventsCollection = await getEventsCollection();
+			const events = await eventsCollection
+				.find({ configId })
+				.sort({ createdAt: 1 })
+				.toArray();
+
+			const exportData = events.map((event) => ({
+				sessionId: event.sessionId,
+				type: event.type,
+				pageId: event.pageId,
+				componentType: event.componentType,
+				componentId: event.componentId,
+				data: event.data ?? {},
+				timestamp: event.timestamp,
+				createdAt: event.createdAt?.toISOString() ?? null,
+			}));
+
+			return { events: exportData };
+		},
+		{
+			params: t.Object({
+				configId: t.String(),
+			}),
+		},
+	)
+	.get(
+		"/:configId/chat-messages",
+		async ({ params: { configId }, set, user }) => {
+			if (!user) {
+				set.status = 401;
+				return { error: "unauthorized", message: "Not authenticated" };
+			}
+
+			// Verify ownership
+			const configsCollection = await getConfigsCollection();
+			const config = await configsCollection.findOne({ configId });
+			if (!config) {
+				set.status = 404;
+				return { error: "not_found", message: "Config not found" };
+			}
+			if (config.owner !== user.id) {
+				set.status = 403;
+				return {
+					error: "forbidden",
+					message: "Not authorized to export this config's data",
+				};
+			}
+
+			// Get all sessions for this config to find their chat messages
+			const sessionsCollection = await getSessionsCollection();
+			const sessions = await sessionsCollection
+				.find({ configId })
+				.project({ id: 1, "user_state.chat_group_id": 1 })
+				.toArray();
+
+			const sessionIds = sessions.map((s) => s.id);
+			const groupIds = new Set<string>();
+
+			// Collect all group IDs (session's own ID for human-AI chat, plus chat_group_id for group chats)
+			for (const session of sessions) {
+				groupIds.add(session.id);
+				if (session.user_state?.chat_group_id) {
+					groupIds.add(session.user_state.chat_group_id as string);
+				}
+			}
+
+			const chatCollection = await getChatMessagesCollection();
+			const messages = await chatCollection
+				.find({
+					$or: [
+						{ groupId: { $in: Array.from(groupIds) } },
+						{ sessionId: { $in: sessionIds } },
+					],
+				})
+				.sort({ createdAt: 1 })
+				.toArray();
+
+			const exportData = messages.map((msg) => ({
+				messageId: msg._id?.toString() ?? null,
+				groupId: msg.groupId,
+				sessionId: msg.sessionId,
+				senderId: msg.senderId,
+				senderType: msg.senderType,
+				content: msg.content,
+				createdAt: msg.createdAt?.toISOString() ?? null,
+			}));
+
+			return { messages: exportData };
+		},
+		{
+			params: t.Object({
+				configId: t.String(),
+			}),
+		},
+	);

--- a/apps/manager/server/src/types.ts
+++ b/apps/manager/server/src/types.ts
@@ -32,3 +32,46 @@ export type MediaListItem = {
 	publicUrl?: string;
 	metadata?: Record<string, unknown> | null;
 };
+
+export type ProlificParams = {
+	prolificPid: string;
+	studyId: string;
+	sessionId: string;
+};
+
+export type SessionDocument = {
+	id: string;
+	configId: string;
+	config: unknown;
+	currentPageId: string;
+	user_state: Record<string, unknown>;
+	prolific?: ProlificParams | null;
+	endedAt: string | null;
+	userId?: string | null;
+	createdAt: Date;
+	updatedAt: Date;
+};
+
+export type EventDocument = {
+	type: string;
+	timestamp: string;
+	sessionId: string;
+	configId: string;
+	pageId: string;
+	componentType: string;
+	componentId: string;
+	data: Record<string, unknown>;
+	idempotencyKey: string;
+	createdAt: Date;
+};
+
+export type ChatMessageDocument = {
+	_id?: import("mongodb").ObjectId;
+	groupId: string;
+	sessionId: string;
+	senderId: string;
+	senderType: "participant" | "agent" | "system";
+	content: string;
+	createdAt: Date;
+	idempotencyKey?: string;
+};


### PR DESCRIPTION
## Summary

- Add `pairit data export <configId>` command to export experiment data
- Support `--format csv|json|jsonl` (default: csv) and `--out <directory>` options
- Export sessions, events, and chat messages as separate files
- Add `/data/:configId/*` API endpoints to manager server with ownership-based auth
- Update CLI README with login and data export documentation
- Fix CLI bin path for proper global linking via `bun link`

## Test plan

- [x] `pairit login` authenticates successfully
- [x] `pairit config upload` uploads a config
- [x] `pairit data export <configId>` exports CSV files
- [x] `pairit data export <configId> --format json` exports JSON
- [x] `pairit data export <configId> --format jsonl --out ./dir` exports JSONL to custom dir
- [x] Global `pairit` command works after `bun link`

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)