### PR TITLE
Add session resumption and retake control

### DIFF
--- a/apps/lab/app/src/App.tsx
+++ b/apps/lab/app/src/App.tsx
@@ -7,6 +7,7 @@ import {
 	AuthRequiredError,
 	advance,
 	type ProlificParams,
+	SessionBlockedError,
 	startSession,
 } from "./lib/api";
 import { useSession } from "./lib/auth-client";
@@ -33,6 +34,7 @@ export default function App() {
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [authRequired, setAuthRequired] = useState(false);
+	const [sessionBlocked, setSessionBlocked] = useState(false);
 
 	useEffect(() => {
 		let canceled = false;
@@ -68,6 +70,7 @@ export default function App() {
 				setEndedAt(null);
 				setEndRedirectUrl(null);
 				setAuthRequired(false);
+				setSessionBlocked(false);
 				return;
 			}
 			setMode(null);
@@ -79,6 +82,7 @@ export default function App() {
 			setEndRedirectUrl(null);
 			setUserState({});
 			setAuthRequired(false);
+			setSessionBlocked(false);
 			setLoading(true);
 			setError(null);
 
@@ -158,6 +162,13 @@ export default function App() {
 				// Handle auth-required experiments
 				if (e instanceof AuthRequiredError) {
 					setAuthRequired(true);
+					setLoading(false);
+					return;
+				}
+
+				// Handle session blocked (already completed, no retakes allowed)
+				if (e instanceof SessionBlockedError) {
+					setSessionBlocked(true);
 					setLoading(false);
 					return;
 				}
@@ -307,6 +318,17 @@ export default function App() {
 						</div>
 						<div className="flex justify-center">
 							<Login />
+						</div>
+					</div>
+				)}
+
+				{!loading && sessionBlocked && (
+					<div className="space-y-4 rounded-3xl border border-slate-200 bg-white p-8 text-center">
+						<div className="text-lg font-medium">
+							Experiment Already Completed
+						</div>
+						<div className="text-sm text-slate-500">
+							You have already completed this experiment and cannot retake it.
 						</div>
 					</div>
 				)}

--- a/apps/lab/server/src/lib/db.ts
+++ b/apps/lab/server/src/lib/db.ts
@@ -91,5 +91,19 @@ export async function ensureIndexes(): Promise<void> {
 		.collection("groups")
 		.createIndex({ groupId: 1 }, { unique: true });
 
+	// Session resumption indexes
+	// OAuth user lookup: find sessions by userId + configId
+	await database
+		.collection("sessions")
+		.createIndex({ userId: 1, configId: 1, createdAt: -1 }, { sparse: true });
+
+	// Prolific participant lookup: find sessions by prolificPid + configId
+	await database
+		.collection("sessions")
+		.createIndex(
+			{ "prolific.prolificPid": 1, configId: 1, createdAt: -1 },
+			{ sparse: true },
+		);
+
 	console.log("[DB] All indexes ensured");
 }

--- a/apps/lab/server/src/types.ts
+++ b/apps/lab/server/src/types.ts
@@ -27,6 +27,7 @@ export type ConfigDocument = {
 	metadata?: Record<string, unknown> | null;
 	config: unknown;
 	requireAuth?: boolean; // Optional auth for lab sessions
+	allowRetake?: boolean; // Allow re-taking completed sessions (defaults to false)
 	createdAt?: Date | null;
 	updatedAt?: Date | null;
 };


### PR DESCRIPTION
Closes #26

## Summary

- Make `POST /sessions/start` idempotent with respect to user+config identity
- In-progress sessions are resumed (`status: "resumed"`)
- Completed sessions with `allowRetake: false` return 409 (`status: "blocked"`)
- Completed sessions with `allowRetake: true` create new session

## Lookup Keys
- **OAuth users**: `userId` + `configId`
- **Prolific**: `prolificPid` + `configId`
- **Anonymous**: no lookup (always new)

## Changes
- Add `allowRetake` field to `ConfigDocument` type
- Add compound indexes for session lookup
- Add `findExistingSession()` helper in sessions route
- Update `/sessions/start` to handle resume/block/create logic
- Add `SessionBlockedError` and 409 handling in frontend API
- Add "Experiment Already Completed" UI for blocked sessions

## Test plan
- [x] New session creation returns `status: "created"`
- [x] Refreshing in-progress session returns `status: "resumed"` with same sessionId
- [x] Completed session with `allowRetake: false` returns 409 with `status: "blocked"`
- [x] Completed session with `allowRetake: true` creates new session
- [x] Local dev configs default to `allowRetake: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)