### PR TITLE
Add groupId scoping for chat memory persistence (#49)

### DIFF
--- a/apps/lab/app/public/configs/multi-chat.json
+++ b/apps/lab/app/public/configs/multi-chat.json
@@ -1,0 +1,153 @@
+{
+	"schema_version": "0.1.0",
+	"initialPageId": "intro",
+	"nodes": [
+		{
+			"id": "intro",
+			"components": [
+				{
+					"type": "text",
+					"props": {
+						"text": "# Multi-Chat Demo\n\nThis experiment demonstrates chat groupId scoping:\n- **Isolated chats**: Each page has separate message history (default)\n- **Shared chats**: Multiple pages share the same conversation\n"
+					}
+				},
+				{
+					"type": "buttons",
+					"props": {
+						"buttons": [
+							{
+								"id": "start",
+								"text": "Start Demo",
+								"action": {
+									"type": "go_to",
+									"target": "chat_1"
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"id": "chat_1",
+			"components": [
+				{
+					"type": "text",
+					"props": {
+						"text": "## Round 1: Financial Advisor\n\nThis chat uses `groupId: \"consultation\"`. Messages will carry over to Round 2.\n"
+					}
+				},
+				{
+					"type": "chat",
+					"props": {
+						"groupId": "consultation",
+						"agents": ["advisor"],
+						"placeholder": "Ask about investment strategies..."
+					}
+				},
+				{
+					"type": "buttons",
+					"props": {
+						"buttons": [
+							{
+								"id": "next",
+								"text": "Continue to Round 2",
+								"action": {
+									"type": "go_to",
+									"target": "chat_2"
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"id": "chat_2",
+			"components": [
+				{
+					"type": "text",
+					"props": {
+						"text": "## Round 2: Same Advisor (Shared Memory)\n\nSame `groupId: \"consultation\"` - the advisor remembers Round 1 conversation.\n"
+					}
+				},
+				{
+					"type": "chat",
+					"props": {
+						"groupId": "consultation",
+						"agents": ["advisor"],
+						"placeholder": "Continue the conversation..."
+					}
+				},
+				{
+					"type": "buttons",
+					"props": {
+						"buttons": [
+							{
+								"id": "next",
+								"text": "Try Isolated Chat",
+								"action": {
+									"type": "go_to",
+									"target": "chat_isolated"
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"id": "chat_isolated",
+			"components": [
+				{
+					"type": "text",
+					"props": {
+						"text": "## Isolated Chat\n\nNo `groupId` prop - this chat is isolated to this page only.\nMessages here won't appear on other pages.\n"
+					}
+				},
+				{
+					"type": "chat",
+					"props": {
+						"agents": ["advisor"],
+						"placeholder": "Start a fresh conversation..."
+					}
+				},
+				{
+					"type": "buttons",
+					"props": {
+						"buttons": [
+							{
+								"id": "finish",
+								"text": "Finish Demo",
+								"action": {
+									"type": "go_to",
+									"target": "outro"
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"id": "outro",
+			"end": true,
+			"components": [
+				{
+					"type": "text",
+					"props": {
+						"text": "# Demo Complete\n\nYou've seen how `groupId` controls chat memory:\n- **Explicit groupId**: Share messages across pages\n- **No groupId**: Isolated per-page history (default)\n"
+					}
+				}
+			]
+		}
+	],
+	"agents": [
+		{
+			"id": "advisor",
+			"model": "gpt-5-mini",
+			"reasoningEffort": "minimal",
+			"system": "You are a friendly financial advisor. Give brief, helpful responses.\nIf the user has spoken to you before in this session, acknowledge the prior conversation.\nKeep responses SHORT - 2-3 sentences max.\n"
+		}
+	]
+}

--- a/apps/lab/app/public/configs/multi-chat.yaml
+++ b/apps/lab/app/public/configs/multi-chat.yaml
@@ -1,0 +1,129 @@
+# Config: Multi-Chat Demo
+# Tests: P0-16 (Chat groupId scoping)
+# Demonstrates: Isolated vs shared chat memory patterns
+
+schema_version: 0.1.0
+initialPageId: intro
+
+pages:
+  - id: intro
+    components:
+      - type: text
+        props:
+          text: |
+            # Multi-Chat Demo
+
+            This experiment demonstrates chat groupId scoping:
+            - **Isolated chats**: Each page has separate message history (default)
+            - **Shared chats**: Multiple pages share the same conversation
+
+      - type: buttons
+        props:
+          buttons:
+            - id: start
+              text: "Start Demo"
+              action:
+                type: go_to
+                target: chat_1
+
+  # --- SHARED CHAT PAGES ---
+  # These two pages share the same groupId, so messages persist across them
+
+  - id: chat_1
+    components:
+      - type: text
+        props:
+          text: |
+            ## Round 1: Financial Advisor
+
+            This chat uses `groupId: "consultation"`. Messages will carry over to Round 2.
+
+      - type: chat
+        props:
+          groupId: "consultation"
+          agents:
+            - advisor
+          placeholder: "Ask about investment strategies..."
+
+      - type: buttons
+        props:
+          buttons:
+            - id: next
+              text: "Continue to Round 2"
+              action:
+                type: go_to
+                target: chat_2
+
+  - id: chat_2
+    components:
+      - type: text
+        props:
+          text: |
+            ## Round 2: Same Advisor (Shared Memory)
+
+            Same `groupId: "consultation"` - the advisor remembers Round 1 conversation.
+
+      - type: chat
+        props:
+          groupId: "consultation"
+          agents:
+            - advisor
+          placeholder: "Continue the conversation..."
+
+      - type: buttons
+        props:
+          buttons:
+            - id: next
+              text: "Try Isolated Chat"
+              action:
+                type: go_to
+                target: chat_isolated
+
+  # --- ISOLATED CHAT PAGE ---
+  # No groupId prop = isolated by default (uses session:pageId)
+
+  - id: chat_isolated
+    components:
+      - type: text
+        props:
+          text: |
+            ## Isolated Chat
+
+            No `groupId` prop - this chat is isolated to this page only.
+            Messages here won't appear on other pages.
+
+      - type: chat
+        props:
+          agents:
+            - advisor
+          placeholder: "Start a fresh conversation..."
+
+      - type: buttons
+        props:
+          buttons:
+            - id: finish
+              text: "Finish Demo"
+              action:
+                type: go_to
+                target: outro
+
+  - id: outro
+    end: true
+    components:
+      - type: text
+        props:
+          text: |
+            # Demo Complete
+
+            You've seen how `groupId` controls chat memory:
+            - **Explicit groupId**: Share messages across pages
+            - **No groupId**: Isolated per-page history (default)
+
+agents:
+  - id: advisor
+    model: "gpt-5-mini"
+    reasoningEffort: minimal
+    system: |
+      You are a friendly financial advisor. Give brief, helpful responses.
+      If the user has spoken to you before in this session, acknowledge the prior conversation.
+      Keep responses SHORT - 2-3 sentences max.

--- a/apps/lab/app/src/routes/Landing.tsx
+++ b/apps/lab/app/src/routes/Landing.tsx
@@ -9,6 +9,7 @@ import {
 	FlaskConical,
 	Mail,
 	MessageCircle,
+	MessagesSquare,
 	Undo2,
 	Users,
 } from "lucide-react";
@@ -64,6 +65,12 @@ const sampleConfigs: DemoConfig[] = [
 		title: "AI mediation",
 		description: "2-person chat with AI facilitator. Open in 2 tabs.",
 		icon: Bot,
+	},
+	{
+		id: "multi-chat",
+		title: "Multi-chat",
+		description: "Isolated vs shared chat memory across pages.",
+		icon: MessagesSquare,
 	},
 ];
 

--- a/apps/lab/app/src/runtime/registry.tsx
+++ b/apps/lab/app/src/runtime/registry.tsx
@@ -12,6 +12,7 @@ export interface RuntimeComponentContext {
 	sessionId?: string | null;
 	userState?: Record<string, unknown>;
 	onUserStateChange?: (updates: Record<string, unknown>) => void;
+	pageId?: string;
 }
 
 export type RuntimeComponentRenderer<

--- a/apps/lab/app/src/runtime/renderer.tsx
+++ b/apps/lab/app/src/runtime/renderer.tsx
@@ -98,6 +98,7 @@ export function PageRenderer({
 			sessionId,
 			userState,
 			onUserStateChange: wrappedOnUserStateChange,
+			pageId: page.id,
 		}),
 		[
 			guardedAction,
@@ -105,6 +106,7 @@ export function PageRenderer({
 			sessionId,
 			userState,
 			wrappedOnUserStateChange,
+			page.id,
 		],
 	);
 

--- a/apps/lab/server/src/lib/agent-runner.ts
+++ b/apps/lab/server/src/lib/agent-runner.ts
@@ -235,6 +235,14 @@ async function persistAndBroadcastMessage(
 }
 
 async function getGroupMembers(groupId: string): Promise<string[]> {
+	// Session-scoped groupId (format: "sessionId:something")
+	// Extract sessionId from prefix and return just that session
+	const colonIndex = groupId.indexOf(":");
+	if (colonIndex > 0) {
+		const sessionId = groupId.substring(0, colonIndex);
+		return [sessionId];
+	}
+
 	const sessionsCollection = await getSessionsCollection();
 	const sessions = await sessionsCollection
 		.find({ "user_state.chat_group_id": groupId })


### PR DESCRIPTION
## Summary

- Chat pages are now **isolated by default** using `session:pageId` format
- Explicit `groupId` prop enables **sharing messages across pages**
- Server updated to authorize and broadcast for session-scoped groupIds

## Changes

- Add `pageId` to `RuntimeComponentContext`
- Add `groupId` prop to `ChatProps`
- Update groupId resolution: `userState.chat_group_id` > `props.groupId` > `session:pageId`
- Update `verifyMembership` and `getGroupMembers` in both `chat.ts` and `agent-runner.ts`
- Add `multi-chat` sample config demonstrating isolated vs shared patterns

## Test plan

- [x] Isolated chat: Messages on one page don't appear on other pages
- [x] Shared chat: Pages with same `groupId` prop share message history
- [x] Matchmaking unchanged: `chat_group_id` from userState still takes precedence
- [x] AI agents respond correctly with new groupId format

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)