### PR TITLE
Fix duplicate agent starts in chat

### DIFF
--- a/apps/lab/app/src/components/Chat/runtime.tsx
+++ b/apps/lab/app/src/components/Chat/runtime.tsx
@@ -54,6 +54,32 @@ type StreamingMessage = {
 	content: string;
 };
 
+const START_AGENTS_IDEMPOTENCY_WINDOW_MS = 5_000;
+const recentStartAgentKeys = new Map<
+	string,
+	{ key: string; expiresAt: number }
+>();
+
+function getStartAgentsIdempotencyKey(
+	sessionId: string,
+	groupId: string,
+): string {
+	const cacheKey = `${sessionId}:${groupId}`;
+	const now = Date.now();
+	const cached = recentStartAgentKeys.get(cacheKey);
+
+	if (cached && cached.expiresAt > now) {
+		return cached.key;
+	}
+
+	const key = crypto.randomUUID();
+	recentStartAgentKeys.set(cacheKey, {
+		key,
+		expiresAt: now + START_AGENTS_IDEMPOTENCY_WINDOW_MS,
+	});
+	return key;
+}
+
 export const ChatRuntime = defineRuntimeComponent<"chat", ChatProps>({
 	type: "chat",
 	renderer: ({ component, context }) => {
@@ -217,7 +243,11 @@ export const ChatRuntime = defineRuntimeComponent<"chat", ChatProps>({
 			hasTriggeredAgents.current = true;
 
 			const timer = setTimeout(() => {
-				startChatAgents(groupId, sessionId).catch((error) => {
+				startChatAgents(
+					groupId,
+					sessionId,
+					getStartAgentsIdempotencyKey(sessionId, groupId),
+				).catch((error) => {
 					console.error("[Chat] Failed to start agents:", error);
 				});
 			}, 300);

--- a/apps/lab/app/src/lib/api.ts
+++ b/apps/lab/app/src/lib/api.ts
@@ -191,12 +191,13 @@ export async function getChatHistory(
 export async function startChatAgents(
 	groupId: string,
 	sessionId: string,
+	idempotencyKey?: string,
 ): Promise<void> {
 	const r = await fetch(`${baseUrl}/chat/${groupId}/start-agents`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		credentials: "include",
-		body: JSON.stringify({ sessionId }),
+		body: JSON.stringify({ sessionId, ...(idempotencyKey && { idempotencyKey }) }),
 	});
 	if (r.status === 403) throw new NotAMemberError();
 	if (!r.ok) throw new Error("Failed to start chat agents");

--- a/apps/lab/server/src/lib/agent-runner.ts
+++ b/apps/lab/server/src/lib/agent-runner.ts
@@ -19,7 +19,23 @@ import { broadcastToSession, getConnectionCount } from "./sse";
 
 const AGENT_TIMEOUT_MS = 60_000;
 
-const activeRuns = new Map<string, AbortController>();
+const activeGroupRuns = new Set<string>();
+
+async function withGroupRunLock(
+	groupId: string,
+	callback: () => Promise<void>,
+): Promise<void> {
+	if (activeGroupRuns.has(groupId)) {
+		return;
+	}
+
+	activeGroupRuns.add(groupId);
+	try {
+		await callback();
+	} finally {
+		activeGroupRuns.delete(groupId);
+	}
+}
 
 function resolveTriggers(agent: AgentConfig): Trigger[] {
 	if (!agent.trigger) return ["every_message"];
@@ -94,59 +110,57 @@ export async function triggerAgents(
 	groupId: string,
 	sessionId: string,
 ): Promise<void> {
-	if (activeRuns.has(groupId)) {
-		return;
-	}
-
-	const sessionConfig = await getSessionConfig(sessionId);
-	if (!sessionConfig) {
-		return;
-	}
-
-	const { configId, currentPageId, sessionState } = sessionConfig;
-
-	const agentIds = await getPageAgentIds(configId, currentPageId);
-	if (agentIds.length === 0) {
-		return;
-	}
-
-	for (const agentId of agentIds) {
-		const agent = await getAgentById(configId, agentId);
-		if (!agent) {
-			console.error(`[Agent] Agent not found: ${agentId}`);
-			continue;
+	await withGroupRunLock(groupId, async () => {
+		const sessionConfig = await getSessionConfig(sessionId);
+		if (!sessionConfig) {
+			return;
 		}
 
-		const triggers = resolveTriggers(agent);
-		let shouldRun = false;
+		const { configId, currentPageId, sessionState } = sessionConfig;
 
-		for (const trigger of triggers) {
-			if (trigger === "every_message") {
-				shouldRun = true;
-				break;
+		const agentIds = await getPageAgentIds(configId, currentPageId);
+		if (agentIds.length === 0) {
+			return;
+		}
+
+		for (const agentId of agentIds) {
+			const agent = await getAgentById(configId, agentId);
+			if (!agent) {
+				console.error(`[Agent] Agent not found: ${agentId}`);
+				continue;
 			}
-			if (typeof trigger === "object" && "every" in trigger) {
-				const count = await countParticipantMessagesSinceAgent(
-					groupId,
-					agent.id,
-				);
-				if (count >= trigger.every) {
+
+			const triggers = resolveTriggers(agent);
+			let shouldRun = false;
+
+			for (const trigger of triggers) {
+				if (trigger === "every_message") {
 					shouldRun = true;
 					break;
 				}
+				if (typeof trigger === "object" && "every" in trigger) {
+					const count = await countParticipantMessagesSinceAgent(
+						groupId,
+						agent.id,
+					);
+					if (count >= trigger.every) {
+						shouldRun = true;
+						break;
+					}
+				}
+				// "on_join" is irrelevant in the message-triggered path
 			}
-			// "on_join" is irrelevant in the message-triggered path
+
+			if (!shouldRun) continue;
+
+			await runAgent(agent, groupId, sessionId, {
+				requireHistory: true,
+				configId,
+				pageId: currentPageId,
+				sessionState,
+			});
 		}
-
-		if (!shouldRun) continue;
-
-		await runAgent(agent, groupId, sessionId, {
-			requireHistory: true,
-			configId,
-			pageId: currentPageId,
-			sessionState,
-		});
-	}
+	});
 }
 
 /**
@@ -157,56 +171,54 @@ export async function triggerJoinAgents(
 	groupId: string,
 	sessionId: string,
 ): Promise<void> {
-	if (activeRuns.has(groupId)) {
-		return;
-	}
+	await withGroupRunLock(groupId, async () => {
+		const chatCollection = await getChatMessagesCollection();
+		const existingCount = await chatCollection.countDocuments(
+			{ groupId },
+			{ limit: 1 },
+		);
 
-	const chatCollection = await getChatMessagesCollection();
-	const existingCount = await chatCollection.countDocuments(
-		{ groupId },
-		{ limit: 1 },
-	);
-
-	const sessionConfig = await getSessionConfig(sessionId);
-	if (!sessionConfig) {
-		return;
-	}
-
-	const { configId, currentPageId, sessionState } = sessionConfig;
-
-	const agentIds = await getPageAgentIds(configId, currentPageId);
-	if (agentIds.length === 0) {
-		return;
-	}
-
-	for (const agentId of agentIds) {
-		const agent = await getAgentById(configId, agentId);
-		if (!agent) {
-			console.error(`[Agent] Agent not found: ${agentId}`);
-			continue;
+		const sessionConfig = await getSessionConfig(sessionId);
+		if (!sessionConfig) {
+			return;
 		}
 
-		const triggers = resolveTriggers(agent);
-		const hasOnJoin = triggers.includes("on_join");
-		const hasExplicitTrigger = agent.trigger !== undefined;
-		const isLegacy = !hasExplicitTrigger && agent.sendFirstMessage === true;
+		const { configId, currentPageId, sessionState } = sessionConfig;
 
-		if (hasOnJoin) {
-			await runAgent(agent, groupId, sessionId, {
-				requireHistory: false,
-				configId,
-				pageId: currentPageId,
-				sessionState,
-			});
-		} else if (isLegacy && existingCount === 0) {
-			await runAgent(agent, groupId, sessionId, {
-				requireHistory: false,
-				configId,
-				pageId: currentPageId,
-				sessionState,
-			});
+		const agentIds = await getPageAgentIds(configId, currentPageId);
+		if (agentIds.length === 0) {
+			return;
 		}
-	}
+
+		for (const agentId of agentIds) {
+			const agent = await getAgentById(configId, agentId);
+			if (!agent) {
+				console.error(`[Agent] Agent not found: ${agentId}`);
+				continue;
+			}
+
+			const triggers = resolveTriggers(agent);
+			const hasOnJoin = triggers.includes("on_join");
+			const hasExplicitTrigger = agent.trigger !== undefined;
+			const isLegacy = !hasExplicitTrigger && agent.sendFirstMessage === true;
+
+			if (hasOnJoin) {
+				await runAgent(agent, groupId, sessionId, {
+					requireHistory: false,
+					configId,
+					pageId: currentPageId,
+					sessionState,
+				});
+			} else if (isLegacy && existingCount === 0) {
+				await runAgent(agent, groupId, sessionId, {
+					requireHistory: false,
+					configId,
+					pageId: currentPageId,
+					sessionState,
+				});
+			}
+		}
+	});
 }
 
 type RunAgentOptions = {
@@ -224,7 +236,6 @@ async function runAgent(
 ): Promise<void> {
 	const { requireHistory = true, configId = "" } = options;
 	const abortController = new AbortController();
-	activeRuns.set(groupId, abortController);
 
 	const timeout = setTimeout(() => {
 		console.log(`[Agent] Timeout for group ${groupId}`);
@@ -378,7 +389,6 @@ async function runAgent(
 		}
 	} finally {
 		clearTimeout(timeout);
-		activeRuns.delete(groupId);
 	}
 }
 

--- a/apps/lab/server/src/routes/chat.ts
+++ b/apps/lab/server/src/routes/chat.ts
@@ -7,10 +7,33 @@
 import { Elysia, t } from "elysia";
 import { MongoServerError, type ObjectId } from "mongodb";
 import { triggerAgents, triggerJoinAgents } from "../lib/agent-runner";
-import { getChatMessagesCollection, getSessionsCollection } from "../lib/db";
+import {
+	getChatMessagesCollection,
+	getIdempotencyCollection,
+	getSessionsCollection,
+} from "../lib/db";
 import { getGroupMembers, verifyMembership } from "../lib/groups";
 import { broadcastToSession } from "../lib/sse";
 import type { ChatMessageDocument } from "../types";
+
+async function checkIdempotency(
+	key: string,
+): Promise<{ duplicate: boolean }> {
+	const collection = await getIdempotencyCollection();
+
+	try {
+		await collection.insertOne({
+			key,
+			createdAt: new Date(),
+		});
+		return { duplicate: false };
+	} catch (err) {
+		if (err instanceof MongoServerError && err.code === 11000) {
+			return { duplicate: true };
+		}
+		throw err;
+	}
+}
 
 export const chatRoutes = new Elysia({ prefix: "/chat" })
 	.post(
@@ -189,13 +212,20 @@ export const chatRoutes = new Elysia({ prefix: "/chat" })
 	.post(
 		"/:groupId/start-agents",
 		async ({ params: { groupId }, body, set }) => {
-			const { sessionId } = body;
+			const { sessionId, idempotencyKey } = body;
 
 			// Verify membership
 			const isMember = await verifyMembership(sessionId, groupId);
 			if (!isMember) {
 				set.status = 403;
 				return { error: "not_a_member" };
+			}
+
+			if (idempotencyKey) {
+				const { duplicate } = await checkIdempotency(idempotencyKey);
+				if (duplicate) {
+					return { ok: true, deduplicated: true };
+				}
 			}
 
 			// Trigger join agents (on_join trigger + legacy sendFirstMessage)
@@ -209,6 +239,7 @@ export const chatRoutes = new Elysia({ prefix: "/chat" })
 			params: t.Object({ groupId: t.String() }),
 			body: t.Object({
 				sessionId: t.String({ minLength: 1 }),
+				idempotencyKey: t.Optional(t.String({ minLength: 1 })),
 			}),
 		},
 	);


### PR DESCRIPTION
## Summary
- make the chat agent-run guard atomic on the server trigger path
- add idempotency handling for the start-agents route
- send a short-window idempotency key from the chat runtime to collapse duplicate mount/remount requests

## Verification
- bun run --filter @pairit/lab-server typecheck
- bun run --filter @pairit/lab-app build