### PR TITLE
Automate media bucket setup in deploy script

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -77,6 +77,26 @@ else
     echo "✅ Repository $REPO_NAME exists."
 fi
 
+# 0b. Setup media bucket (public-read for participant-facing assets)
+MEDIA_BUCKET="${STORAGE_PATH:-pairit-lab-media}"
+echo "🔧 Checking media bucket gs://$MEDIA_BUCKET..."
+if ! gcloud storage buckets describe "gs://$MEDIA_BUCKET" --project "$PROJECT_ID" &>/dev/null; then
+    echo "🪣 Creating bucket gs://$MEDIA_BUCKET..."
+    gcloud storage buckets create "gs://$MEDIA_BUCKET" \
+        --project="$PROJECT_ID" \
+        --location="$REGION" \
+        --uniform-bucket-level-access
+else
+    echo "✅ Bucket gs://$MEDIA_BUCKET exists."
+fi
+# Grant public read so the stable public URL returned by the manager works.
+# Idempotent: re-applying the binding is a no-op.
+gcloud storage buckets add-iam-policy-binding "gs://$MEDIA_BUCKET" \
+    --project="$PROJECT_ID" \
+    --member=allUsers \
+    --role=roles/storage.objectViewer >/dev/null
+echo "✅ Bucket gs://$MEDIA_BUCKET is publicly readable."
+
 # Define Image Paths
 LAB_IMAGE="$REGION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/pairit-lab"
 MANAGER_IMAGE="$REGION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/pairit-manager"
@@ -254,4 +274,3 @@ echo "1. Add OAuth redirect URIs to Google Cloud Console:"
 echo "   - ${MANAGER_URL}/api/auth/callback/google"
 echo "   - ${LAB_SERVICE_URL}/api/auth/callback/google"
 echo "2. Whitelist Cloud Run IPs in MongoDB Atlas (or use 0.0.0.0/0 for dev)"
-echo "3. Verify IAM permissions for GCS bucket '${STORAGE_PATH:-pairit-lab-media}'"


### PR DESCRIPTION
## Summary
- Create `gs://pairit-lab-media` if missing and grant `allUsers:objectViewer` so the stable public URL returned by `pairit media upload` actually works.
- Removes the manual "Verify IAM permissions for GCS bucket" reminder from the post-deploy checklist — it's automated now.

## Why
The bucket had UBLA on with no public-read binding, so every URL returned by the CLI 403'd. Diagnosed by inspecting `iamConfiguration` on the live bucket; the binding was added by hand and a fresh upload (`adrian.png`, then a test cat picture) confirmed it works end-to-end. This change makes a fresh project bring-up self-contained.

Both new gcloud commands are idempotent on re-run.

## Test plan
- [x] Manual `gcloud storage buckets add-iam-policy-binding ... allUsers ...` applied to live bucket; existing object now returns `HTTP/2 200` instead of 403.
- [x] CLI upload via `pairit media upload` returns a stable public URL that loads in the browser.
- [ ] Re-run `bash scripts/deploy.sh` against an existing project — should print "✅ Bucket exists" and "✅ Bucket is publicly readable" without errors.
- [ ] Run against a fresh project — should create the bucket and apply the binding without manual steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)