### PR TITLE
Stop CLI from loading repo-local .env

### DIFF
--- a/apps/manager/cli/README.md
+++ b/apps/manager/cli/README.md
@@ -99,7 +99,16 @@ Notes:
 - `{configId}-events.{format}` — session ID, event type, component info, payload, timestamps
 - `{configId}-chat-messages.{format}` — group ID, session ID, sender, content, timestamps
 
-All hosted commands require the manager service to be reachable (Cloud Run deployment or local server). Set `PAIRIT_API_URL` to point to the desired target. When unset, the CLI defaults to `http://localhost:3002`.
+All hosted commands require the manager service to be reachable (Cloud Run deployment or local server). By default the CLI talks to the deployed manager. Override via shell environment variables when needed:
+
+- `PAIRIT_API_URL` — manager base URL (e.g. `http://localhost:3002` for local dev)
+- `PAIRIT_LAB_URL` — lab base URL used to print the survey link after `config upload`
+- `PAIRIT_CREDENTIALS_BACKEND` — `keychain` (default when available) or `file`
+- `PAIRIT_MAX_INLINE_MEDIA_BYTES` — switch to signed-URL upload above this size (default 5 MiB)
+
+```bash
+PAIRIT_API_URL=http://localhost:3002 pairit config list
+```
 
 ## Development
 

--- a/apps/manager/cli/package.json
+++ b/apps/manager/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pairit",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "CLI for the Pairit behavioral science experiment platform",
   "type": "module",
   "bin": {
@@ -35,7 +35,6 @@
     "@types/open": "^6.2.1",
     "better-auth": "^1.4.7",
     "commander": "^12.1.0",
-    "dotenv": "^17.2.3",
     "open": "^11.0.0",
     "typescript": "^5.9.3",
     "yaml": "^2.6.0"

--- a/apps/manager/cli/src/index.ts
+++ b/apps/manager/cli/src/index.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import "dotenv/config";
 import { createHash } from "node:crypto";
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
@@ -31,7 +30,7 @@ const program = new Command();
 program
 	.name("pairit")
 	.description("CLI for Pairit experiment configs")
-	.version("0.1.3");
+	.version("0.1.6");
 
 program
 	.command("login")

--- a/bun.lock
+++ b/bun.lock
@@ -61,7 +61,7 @@
     },
     "apps/manager/cli": {
       "name": "pairit",
-      "version": "0.1.0",
+      "version": "0.1.6",
       "bin": {
         "pairit": "dist/index.js",
       },
@@ -70,7 +70,6 @@
         "@types/open": "^6.2.1",
         "better-auth": "^1.4.7",
         "commander": "^12.1.0",
-        "dotenv": "^17.2.3",
         "open": "^11.0.0",
         "typescript": "^5.9.3",
         "yaml": "^2.6.0",
@@ -625,8 +624,6 @@
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
-
-    "dotenv": ["dotenv@17.2.3", "", {}, "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 


### PR DESCRIPTION
## Summary
- Removes `import "dotenv/config"` from `apps/manager/cli/src/index.ts`. The published `pairit` binary was slurping any `.env` in cwd, so running it inside the repo silently routed to `http://localhost:3002` (the dev manager) instead of the deployed one.
- Bumps CLI to `0.1.6` (also fixes the stale `0.1.3` in commander's `.version()`), drops the now-unused `dotenv` devDep.
- Fixes the README — it claimed the default was `http://localhost:3002`, when the code actually defaults to the deployed manager. Documents the `PAIRIT_*` env vars users may want to set.

After this, `PAIRIT_API_URL` / `PAIRIT_LAB_URL` / `PAIRIT_CREDENTIALS_BACKEND` / `PAIRIT_MAX_INLINE_MEDIA_BYTES` come from the user's shell only — the standard hosted-CLI pattern (gh, vercel, etc.).

Dev servers are unaffected: `bun run dev` auto-loads `.env` itself; it never depended on the CLI's dotenv import.

Closes #91

## Test plan
- [x] `tsc --noEmit` clean
- [x] `bun build` clean; bundled `dist/index.js` contains zero `dotenv` references
- [x] Rebuilt binary reports `0.1.6` from `--version`
- [ ] After merge: `cd apps/manager/cli && npm publish` to ship the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)