### PR TITLE
Clean up CLI login output

### DIFF
--- a/apps/manager/cli/package.json
+++ b/apps/manager/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pairit",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "CLI for the Pairit behavioral science experiment platform",
   "type": "module",
   "bin": {

--- a/apps/manager/cli/src/auth.ts
+++ b/apps/manager/cli/src/auth.ts
@@ -67,10 +67,10 @@ export async function login() {
 		const redirectUri = `http://127.0.0.1:${port}`;
 		const targetUrl = `${loginUrl}?cli_redirect_uri=${encodeURIComponent(redirectUri)}`;
 
-		console.log("Opening browser for authentication...");
+		console.log(`Opening ${loginUrl} in your browser...`);
 		await open(targetUrl);
 
-		console.log(`Waiting for authentication at ${redirectUri}...`);
+		console.log("Waiting for sign-in to complete...");
 
 		// Receive authorization code (not the token directly for security)
 		const authCode = await new Promise<string>((resolve, reject) => {

--- a/apps/manager/cli/src/index.ts
+++ b/apps/manager/cli/src/index.ts
@@ -30,7 +30,7 @@ const program = new Command();
 program
 	.name("pairit")
 	.description("CLI for Pairit experiment configs")
-	.version("0.1.6");
+	.version("0.1.7");
 
 program
 	.command("login")


### PR DESCRIPTION
## Summary
- `pairit login` printed `Waiting for authentication at http://127.0.0.1:<port>...`, which looked like the user was supposed to go to that URL. It's actually just the local OAuth callback listener — implementation detail that shouldn't leak into stdout.
- Now prints the actual manager URL being opened in the browser, then a generic "Waiting for sign-in to complete..." line.
- Bumps to 0.1.7.

Before:
```
Initiating login...
Opening browser for authentication...
Waiting for authentication at http://127.0.0.1:61092...
```

After:
```
Initiating login...
Opening https://manager-432501290611.us-central1.run.app/login in your browser...
Waiting for sign-in to complete...
```

## Test plan
- [x] `tsc --noEmit` clean
- [x] `bun build` clean
- [ ] After publish: `pairit login` shows the new messaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)