### PR TITLE
Add configId indexes for data export sorts

### DIFF
--- a/apps/lab/server/src/lib/db.ts
+++ b/apps/lab/server/src/lib/db.ts
@@ -73,6 +73,10 @@ export async function ensureIndexes(): Promise<void> {
 	await database
 		.collection("events")
 		.createIndex({ sessionId: 1, createdAt: 1 });
+	// Data export sort: find({configId}).sort({createdAt})
+	await database
+		.collection("events")
+		.createIndex({ configId: 1, createdAt: 1 });
 	await database
 		.collection("events")
 		.createIndex({ idempotencyKey: 1 }, { unique: true, sparse: true });
@@ -96,6 +100,15 @@ export async function ensureIndexes(): Promise<void> {
 	await database
 		.collection("groups")
 		.createIndex({ groupId: 1 }, { unique: true });
+	// Data export sort: find({configId}).sort({matchedAt})
+	await database
+		.collection("groups")
+		.createIndex({ configId: 1, matchedAt: 1 });
+
+	// Data export sort: find({configId}).sort({createdAt})
+	await database
+		.collection("sessions")
+		.createIndex({ configId: 1, createdAt: 1 });
 
 	// Session resumption indexes
 	// OAuth user lookup: find sessions by userId + configId

--- a/apps/lab/server/src/lib/db.ts
+++ b/apps/lab/server/src/lib/db.ts
@@ -73,7 +73,6 @@ export async function ensureIndexes(): Promise<void> {
 	await database
 		.collection("events")
 		.createIndex({ sessionId: 1, createdAt: 1 });
-	// Data export sort: find({configId}).sort({createdAt})
 	await database
 		.collection("events")
 		.createIndex({ configId: 1, createdAt: 1 });
@@ -100,12 +99,10 @@ export async function ensureIndexes(): Promise<void> {
 	await database
 		.collection("groups")
 		.createIndex({ groupId: 1 }, { unique: true });
-	// Data export sort: find({configId}).sort({matchedAt})
 	await database
 		.collection("groups")
 		.createIndex({ configId: 1, matchedAt: 1 });
 
-	// Data export sort: find({configId}).sort({createdAt})
 	await database
 		.collection("sessions")
 		.createIndex({ configId: 1, createdAt: 1 });


### PR DESCRIPTION
## Summary
- `/data/:configId/{sessions,events,groups}` exports do `find({configId}).sort({...})` with no supporting index, so Mongo runs an in-memory sort
- On Atlas Flex (and free M0), in-memory sort is capped at 32 MB and `allowDiskUse` is blocked — once a config's data crosses that, the export fails with `QueryExceededMemoryLimitNoDiskUseAllowed` (code 292)
- Observed in prod on config `67e0474ed3e2` (~30 pilot participants) — repeated 500s on `/data/67e0474ed3e2/sessions`
- Adds `(configId, createdAt)` on `sessions` and `events`, `(configId, matchedAt)` on `groups` so sorts are index-backed and stream instead of buffering

## Why these specifically
`workspace_documents` already has `(configId, updatedAt)`. `chat_messages` uses a `$or` on `groupId`/`sessionId` and has its own index pattern — not affected by this failure mode.

## Refs
- [Atlas Flex limitations](https://www.mongodb.com/docs/atlas/reference/flex-limitations/) — confirms 32 MB sort cap + no `allowDiskUse`

## Test plan
- [ ] Merge + deploy lab-server (which runs `ensureIndexes()` at startup)
- [ ] Verify in Atlas that the three new indexes exist on `sessions`, `events`, `groups`
- [ ] Re-run `pairit data export 67e0474ed3e2` as the config owner and confirm it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)