### PR TITLE
Denormalize configId onto chat_messages

### DIFF
--- a/apps/lab/server/src/lib/agent-runner.ts
+++ b/apps/lab/server/src/lib/agent-runner.ts
@@ -346,6 +346,7 @@ async function runAgent(
 			await persistAndBroadcastMessage(
 				groupId,
 				sessionId,
+				configId,
 				senderId,
 				"agent",
 				fullText,
@@ -382,6 +383,7 @@ async function runAgent(
 			await persistAndBroadcastMessage(
 				groupId,
 				sessionId,
+				configId,
 				"system",
 				"system",
 				"Sorry, I encountered an error. Please try again.",
@@ -408,6 +410,7 @@ async function loadChatHistory(groupId: string): Promise<ChatMessage[]> {
 async function persistAndBroadcastMessage(
 	groupId: string,
 	sessionId: string,
+	configId: string,
 	senderId: string,
 	senderType: "participant" | "agent" | "system",
 	content: string,
@@ -419,6 +422,7 @@ async function persistAndBroadcastMessage(
 	const result = await collection.insertOne({
 		groupId,
 		sessionId,
+		configId,
 		senderId,
 		senderType,
 		content,

--- a/apps/lab/server/src/lib/db.ts
+++ b/apps/lab/server/src/lib/db.ts
@@ -94,6 +94,9 @@ export async function ensureIndexes(): Promise<void> {
 		.createIndex({ groupId: 1, createdAt: 1 });
 	await database
 		.collection("chat_messages")
+		.createIndex({ configId: 1, createdAt: 1 });
+	await database
+		.collection("chat_messages")
 		.createIndex({ idempotencyKey: 1 }, { unique: true, sparse: true });
 
 	await database

--- a/apps/lab/server/src/routes/chat.ts
+++ b/apps/lab/server/src/routes/chat.ts
@@ -48,6 +48,16 @@ export const chatRoutes = new Elysia({ prefix: "/chat" })
 				return { error: "not_a_member" };
 			}
 
+			const sessionsCollection = await getSessionsCollection();
+			const session = await sessionsCollection.findOne(
+				{ id: sessionId },
+				{ projection: { configId: 1 } },
+			);
+			if (!session) {
+				set.status = 404;
+				return { error: "session_not_found" };
+			}
+
 			const collection = await getChatMessagesCollection();
 
 			// Check idempotency if key provided
@@ -66,6 +76,7 @@ export const chatRoutes = new Elysia({ prefix: "/chat" })
 			const message: ChatMessageDocument = {
 				groupId,
 				sessionId,
+				configId: session.configId,
 				senderId: sessionId,
 				senderType: senderType ?? "participant",
 				content,
@@ -97,8 +108,7 @@ export const chatRoutes = new Elysia({ prefix: "/chat" })
 			const effectiveSenderType = senderType ?? "participant";
 			let messagesSent: number | undefined;
 			if (effectiveSenderType === "participant") {
-				const sessions = await getSessionsCollection();
-				const updatedSession = await sessions.findOneAndUpdate(
+				const updatedSession = await sessionsCollection.findOneAndUpdate(
 					{ id: sessionId },
 					{
 						$inc: { "session_state.chat.messages_sent": 1 },

--- a/packages/db/types.ts
+++ b/packages/db/types.ts
@@ -70,6 +70,7 @@ export type ChatMessageDocument = {
 	_id?: ObjectId;
 	groupId: string;
 	sessionId: string;
+	configId: string;
 	senderId: string;
 	senderType: "participant" | "agent" | "system";
 	content: string;

--- a/scripts/backfill-chat-messages-configid.ts
+++ b/scripts/backfill-chat-messages-configid.ts
@@ -1,0 +1,77 @@
+/**
+ * One-time backfill: stamp `configId` onto existing `chat_messages` documents.
+ *
+ * For each chat_messages doc missing `configId`, resolves it by looking up the
+ * referenced session and copying its `configId`. Messages whose session no
+ * longer exists are reported and left untouched.
+ *
+ * Safe to re-run: only operates on docs where `configId` is missing.
+ *
+ * Usage:
+ *   bun --env-file=.env scripts/backfill-chat-messages-configid.ts
+ */
+
+import { closeDB, connectDB } from "../packages/db";
+
+async function main() {
+	const db = await connectDB();
+	const chatMessages = db.collection("chat_messages");
+	const sessions = db.collection("sessions");
+
+	const total = await chatMessages.countDocuments({
+		configId: { $exists: false },
+	});
+	console.log(`Found ${total} chat_messages without configId.`);
+
+	if (total === 0) {
+		await closeDB();
+		return;
+	}
+
+	const sessionIds: string[] = await chatMessages.distinct("sessionId", {
+		configId: { $exists: false },
+	});
+	console.log(`Resolving ${sessionIds.length} distinct sessionId(s)...`);
+
+	const sessionDocs = await sessions
+		.find(
+			{ id: { $in: sessionIds } },
+			{ projection: { id: 1, configId: 1 } },
+		)
+		.toArray();
+
+	const sessionToConfig = new Map<string, string>();
+	for (const s of sessionDocs) {
+		if (typeof s.id === "string" && typeof s.configId === "string") {
+			sessionToConfig.set(s.id, s.configId);
+		}
+	}
+
+	const missing = sessionIds.filter((id) => !sessionToConfig.has(id));
+	if (missing.length > 0) {
+		console.warn(
+			`Warning: ${missing.length} sessionId(s) referenced by chat_messages have no matching session. Their messages will be skipped.`,
+		);
+		console.warn(`First few: ${missing.slice(0, 5).join(", ")}`);
+	}
+
+	let updated = 0;
+	for (const [sessionId, configId] of sessionToConfig) {
+		const result = await chatMessages.updateMany(
+			{ sessionId, configId: { $exists: false } },
+			{ $set: { configId } },
+		);
+		updated += result.modifiedCount;
+	}
+
+	console.log(
+		`Backfill complete: ${updated} chat_messages updated, ${total - updated} left unchanged.`,
+	);
+
+	await closeDB();
+}
+
+main().catch((err) => {
+	console.error("Backfill failed:", err);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

Stamps `configId` on every new `chat_messages` write and adds a `{configId, createdAt}` compound index, so the chat-messages export can switch to a flat `find({ configId })` instead of the current `$or` of two `$in` arrays (one of which is unindexed, both of which scale with session count and can hit Mongo's 16MB BSON query limit on large studies).

Includes a one-off backfill for existing rows. **Does not change the export query** — that's a follow-up PR after the backfill is run.

Part of #99 (item 1).

## Changes

- `packages/db/types.ts` — add required `configId: string` to `ChatMessageDocument`
- `apps/lab/server/src/lib/db.ts` — `createIndex({configId:1, createdAt:1})` on `chat_messages`
- `apps/lab/server/src/routes/chat.ts` — participant route looks up `configId` from session and stamps it (reuses the lookup for the existing `messages_sent` update)
- `apps/lab/server/src/lib/agent-runner.ts` — `persistAndBroadcastMessage` takes `configId`; both call sites already had it in scope
- `scripts/backfill-chat-messages-configid.ts` — idempotent backfill, resolves `configId` via `sessionId → sessions.configId`

## Deploy runbook

1. Merge + deploy lab server (`bash scripts/deploy.sh`)
2. Run `bun --env-file=.env scripts/backfill-chat-messages-configid.ts`
3. Verify `db.chat_messages.countDocuments({configId:{$exists:false}})` returns 0
4. Open follow-up PR swapping `data.ts` export query from `$or` to `{ configId }`

## Test plan

- [x] Type check: `tsc --noEmit` clean for `lab/server`, `manager/server`, `packages/db`
- [x] Index verified on Atlas after `ensureIndexes()` runs
- [x] Backfill: stamped 41,890 existing docs on first run
- [x] Backfill idempotent: re-run touched only newly-arrived rows
- [x] Participant write: end-to-end curl POST to local lab-server → inserted doc has `configId` matching session's `configId`
- [ ] Agent write: not exercised in CI (LLM cost) — verify by triggering one agent reply via the lab UI and confirming the inserted doc has `configId`

## Notes

- 4 pre-existing orphan sessionIds (`agent:advisor/dealer/facilitator/writer`) from old data have malformed sessionIds — their ~few docs will be skipped by the backfill and excluded from future `{configId}`-filtered exports. Not addressed here; can be backfilled via `groupId → groups.configId` later if needed.
- Until the deploy ships, the running Cloud Run lab-server will continue writing `chat_messages` without `configId`. Re-run the backfill after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)