### PR TITLE
Swap chat-messages export query to {configId}

### DIFF
--- a/apps/manager/server/src/routes/data.ts
+++ b/apps/manager/server/src/routes/data.ts
@@ -138,32 +138,9 @@ export const dataRoutes = new Elysia({ prefix: "/data" })
 				};
 			}
 
-			// Get all sessions for this config to find their chat messages
-			const sessionsCollection = await getSessionsCollection();
-			const sessions = await sessionsCollection
-				.find({ configId })
-				.project({ id: 1, "session_state.chat_group_id": 1 })
-				.toArray();
-
-			const sessionIds = sessions.map((s) => s.id);
-			const groupIds = new Set<string>();
-
-			// Collect all group IDs (session's own ID for human-AI chat, plus chat_group_id for group chats)
-			for (const session of sessions) {
-				groupIds.add(session.id);
-				if (session.session_state?.chat_group_id) {
-					groupIds.add(session.session_state.chat_group_id as string);
-				}
-			}
-
 			const chatCollection = await getChatMessagesCollection();
 			const messages = await chatCollection
-				.find({
-					$or: [
-						{ groupId: { $in: Array.from(groupIds) } },
-						{ sessionId: { $in: sessionIds } },
-					],
-				})
+				.find({ configId })
 				.sort({ createdAt: 1 })
 				.toArray();
 

--- a/scripts/backfill-chat-messages-configid-via-groupid.ts
+++ b/scripts/backfill-chat-messages-configid-via-groupid.ts
@@ -1,0 +1,79 @@
+/**
+ * Second-pass backfill: stamp `configId` onto orphan chat_messages whose
+ * `sessionId` does not resolve to any session document.
+ *
+ * The first-pass backfill (backfill-chat-messages-configid.ts) skipped these
+ * because their `sessionId` is shaped like `agent:<name>` (known bad legacy
+ * data from Feb 2026), so no session lookup is possible. Instead, resolve
+ * `configId` via the message's `groupId` by finding sibling messages with the
+ * same groupId that already have `configId`.
+ *
+ * Safe to re-run: only operates on docs where `configId` is missing.
+ *
+ * Usage:
+ *   bun --env-file=.env scripts/backfill-chat-messages-configid-via-groupid.ts
+ */
+
+import { closeDB, connectDB } from "../packages/db";
+
+async function main() {
+	const db = await connectDB();
+	const chatMessages = db.collection("chat_messages");
+
+	const total = await chatMessages.countDocuments({
+		configId: { $exists: false },
+	});
+	console.log(`Found ${total} chat_messages without configId.`);
+
+	if (total === 0) {
+		await closeDB();
+		return;
+	}
+
+	const groupIds: string[] = await chatMessages.distinct("groupId", {
+		configId: { $exists: false },
+	});
+	console.log(`Resolving ${groupIds.length} distinct groupId(s) via siblings...`);
+
+	const groupToConfig = new Map<string, string>();
+	const unresolved: string[] = [];
+
+	for (const groupId of groupIds) {
+		const sibling = await chatMessages.findOne(
+			{ groupId, configId: { $exists: true } },
+			{ projection: { configId: 1 } },
+		);
+		if (sibling && typeof sibling.configId === "string") {
+			groupToConfig.set(groupId, sibling.configId);
+		} else {
+			unresolved.push(groupId);
+		}
+	}
+
+	if (unresolved.length > 0) {
+		console.warn(
+			`Warning: ${unresolved.length} groupId(s) have no sibling with configId. Their messages will be skipped.`,
+		);
+		console.warn(`First few: ${unresolved.slice(0, 5).join(", ")}`);
+	}
+
+	let updated = 0;
+	for (const [groupId, configId] of groupToConfig) {
+		const result = await chatMessages.updateMany(
+			{ groupId, configId: { $exists: false } },
+			{ $set: { configId } },
+		);
+		updated += result.modifiedCount;
+	}
+
+	console.log(
+		`Backfill complete: ${updated} chat_messages updated, ${total - updated} left unchanged.`,
+	);
+
+	await closeDB();
+}
+
+main().catch((err) => {
+	console.error("Backfill failed:", err);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

Follow-up to #100. Now that every `chat_messages` row carries `configId`, swap the manager's chat-messages export from the indirect `$or` query to a direct `{ configId }` lookup.

**Before** — fetch all sessions for the config, build group/session id arrays, then:
```ts
{ $or: [{ groupId: { $in: [...] } }, { sessionId: { $in: [...] } }] }
```
The `groupId` branch had no supporting compound index, and both `$in` arrays grew unbounded with config size, risking the 16MB BSON query document limit.

**After**:
```ts
{ configId }
```
Served by the `{ configId: 1, createdAt: 1 }` index added in #100. No upfront sessions query, no `$in` arrays, no `$or`.

Closes the read-path half of #99's chat-messages export issue.

## Bonus: fixes a latent bug in the old query

Equivalence verification against prod found that the new query returns **34 additional messages** for `ai-chat` (+10), `multi-chat` (+17), and `workspace-demo` (+7). These messages have channel-suffixed groupIds (`{sessionId}:chat`, `{sessionId}:consultation`, `{sessionId}:chat_isolated`, `{sessionId}:workspace`) which the old `$or` query never matched — it only built its groupIds set from bare `session.id` and `session_state.chat_group_id`. The new query catches them correctly via `configId`. These are real messages that have been silently missing from exports.

## Second-pass orphan backfill

#100's backfill skipped 81 messages with `sessionId: agent:*` (known bad Feb 2026 data with no matching session). To keep this PR strictly additive in exports, this branch adds `scripts/backfill-chat-messages-configid-via-groupid.ts` which resolves `configId` for those orphans by copying from a sibling message with the same `groupId`. Already run against prod — all 81 orphans now have correct `configId`.

## Deploy ordering safety

This PR is only safe to ship because #100 is merged + deployed + both backfills are complete. Verified prior to opening:
- All live chat_messages writes include `configId` (lab revision `lab-00039-mlj`)
- First-pass backfill complete (1168 messages updated)
- Second-pass orphan backfill complete (81 messages updated)
- Equivalence check: 0 messages missing in new query; 34 extras = the latent-bug fix above

## Test plan

- [ ] CI typecheck + lint
- [ ] Manually run chat-messages export against one of the three affected configs, confirm the 34 newly-included messages are real participant-AI chat history (not garbage)
- [ ] Confirm Mongo profiler / explain shows query uses `configId_1_createdAt_1` index

🤖 Generated with [Claude Code](https://claude.com/claude-code)