### PR TITLE
Push survey-responses filter into Mongo

### DIFF
--- a/apps/manager/server/src/routes/data.ts
+++ b/apps/manager/server/src/routes/data.ts
@@ -235,19 +235,15 @@ export const dataRoutes = new Elysia({ prefix: "/data" })
 			const events = await eventsCollection
 				.find({
 					configId,
-					componentType: { $in: ["survey", "paged_survey"] },
+					$or: [
+						{ componentType: "survey" },
+						{ componentType: "paged_survey", "data.status": "completed" },
+					],
 				})
 				.sort({ createdAt: 1 })
 				.toArray();
 
-			// Filter out paged survey per-page events (keep only completions)
-			const filtered = events.filter(
-				(event) =>
-					event.componentType !== "paged_survey" ||
-					event.data?.status === "completed",
-			);
-
-			const exportData = filtered.map((event) => ({
+			const exportData = events.map((event) => ({
 				sessionId: event.sessionId,
 				pageId: event.pageId,
 				componentId: event.componentId,


### PR DESCRIPTION
## Summary

Item 4 from #99. Replace the in-JS paged-survey non-completion filter in `survey-responses` with an `$or` in the Mongo query so per-page `paged_survey` events are dropped at query time, not materialized then filtered.

**Before**:
```ts
find({ configId, componentType: { \$in: ["survey", "paged_survey"] } })
  .toArray()
  .filter((e) => e.componentType !== "paged_survey" || e.data?.status === "completed")
```

**After**:
```ts
find({
  configId,
  \$or: [
    { componentType: "survey" },
    { componentType: "paged_survey", "data.status": "completed" },
  ],
})
```

Existing `{ configId: 1, createdAt: 1 }` index on `events` still serves the `configId` equality + `createdAt` sort. The `\$or` is a residual filter, same as today's `\$in`.

## Verification

Equivalence checked against prod: 139 configs with survey events, **0 mismatches**.

## Test plan

- [ ] CI typecheck + lint
- [ ] Smoke-test the survey-responses export against a config that uses paged surveys, confirm per-page (non-completion) events still don't appear in the export

🤖 Generated with [Claude Code](https://claude.com/claude-code)