### PR TITLE
Add cursor pagination to export endpoints + CLI

### DIFF
--- a/apps/manager/cli/src/index.ts
+++ b/apps/manager/cli/src/index.ts
@@ -653,6 +653,26 @@ async function resolvePath(configPath: string): Promise<string> {
 	return absolute;
 }
 
+async function fetchAllPages<T>(
+	pathname: string,
+	extract: (response: unknown) => T[],
+): Promise<T[]> {
+	const all: T[] = [];
+	let since: string | null = null;
+	do {
+		const url = since
+			? `${pathname}?since=${encodeURIComponent(since)}`
+			: pathname;
+		const response = (await callFunctions(url, { method: "GET" })) as
+			| { nextCursor?: string | null }
+			| undefined;
+		if (!response) break;
+		all.push(...extract(response));
+		since = response.nextCursor ?? null;
+	} while (since);
+	return all;
+}
+
 async function callFunctions(
 	pathname: string,
 	init: RequestInit = {},
@@ -740,41 +760,44 @@ async function exportData(
 
 	console.log(`Exporting data for ${configId} in ${format} format...`);
 
-	// Fetch all data in parallel
+	const cfg = encodeURIComponent(configId);
 	const [
-		sessionsRes,
-		eventsRes,
-		messagesRes,
-		groupsRes,
-		surveyRes,
-		workspaceRes,
+		sessions,
+		events,
+		messages,
+		groups,
+		surveyResponses,
+		workspaceDocuments,
 	] = await Promise.all([
-		callFunctions(`/data/${encodeURIComponent(configId)}/sessions`, {
-			method: "GET",
-		}) as Promise<{ sessions: SessionExport[] }>,
-		callFunctions(`/data/${encodeURIComponent(configId)}/events`, {
-			method: "GET",
-		}) as Promise<{ events: EventExport[] }>,
-		callFunctions(`/data/${encodeURIComponent(configId)}/chat-messages`, {
-			method: "GET",
-		}) as Promise<{ messages: ChatMessageExport[] }>,
-		callFunctions(`/data/${encodeURIComponent(configId)}/groups`, {
-			method: "GET",
-		}) as Promise<{ groups: GroupExport[] }>,
-		callFunctions(`/data/${encodeURIComponent(configId)}/survey-responses`, {
-			method: "GET",
-		}) as Promise<{ surveyResponses: SurveyResponseExport[] }>,
-		callFunctions(`/data/${encodeURIComponent(configId)}/workspace-documents`, {
-			method: "GET",
-		}) as Promise<{ workspaceDocuments: WorkspaceDocumentExport[] }>,
+		fetchAllPages<SessionExport>(
+			`/data/${cfg}/sessions`,
+			(r) => (r as { sessions?: SessionExport[] }).sessions ?? [],
+		),
+		fetchAllPages<EventExport>(
+			`/data/${cfg}/events`,
+			(r) => (r as { events?: EventExport[] }).events ?? [],
+		),
+		fetchAllPages<ChatMessageExport>(
+			`/data/${cfg}/chat-messages`,
+			(r) => (r as { messages?: ChatMessageExport[] }).messages ?? [],
+		),
+		fetchAllPages<GroupExport>(
+			`/data/${cfg}/groups`,
+			(r) => (r as { groups?: GroupExport[] }).groups ?? [],
+		),
+		fetchAllPages<SurveyResponseExport>(
+			`/data/${cfg}/survey-responses`,
+			(r) =>
+				(r as { surveyResponses?: SurveyResponseExport[] }).surveyResponses ??
+				[],
+		),
+		fetchAllPages<WorkspaceDocumentExport>(
+			`/data/${cfg}/workspace-documents`,
+			(r) =>
+				(r as { workspaceDocuments?: WorkspaceDocumentExport[] })
+					.workspaceDocuments ?? [],
+		),
 	]);
-
-	const sessions = sessionsRes.sessions ?? [];
-	const events = eventsRes.events ?? [];
-	const messages = messagesRes.messages ?? [];
-	const groups = groupsRes.groups ?? [];
-	const surveyResponses = surveyRes.surveyResponses ?? [];
-	const workspaceDocuments = workspaceRes.workspaceDocuments ?? [];
 
 	// Write each data type to its own file
 	await writeExportFile(

--- a/apps/manager/server/src/lib/cursor.ts
+++ b/apps/manager/server/src/lib/cursor.ts
@@ -1,0 +1,58 @@
+/**
+ * Cursor pagination helpers for /data/* export endpoints.
+ *
+ * Cursor wire format: `<sortField-ISO-8601>,<_id-hex>` — exclusive.
+ * Tiebreaker on _id handles equal-timestamp rows. Sort becomes
+ * `{ [sortField]: 1, _id: 1 }` to make the cursor deterministic.
+ */
+
+import { ObjectId } from "mongodb";
+
+const DEFAULT_LIMIT = 5000;
+const MAX_LIMIT = 20000;
+
+export type Cursor = { sortValue: Date; id: ObjectId };
+
+export class CursorError extends Error {}
+
+export function parseCursor(since: string | undefined): Cursor | null {
+	if (!since) return null;
+	const idx = since.lastIndexOf(",");
+	if (idx < 0) throw new CursorError("invalid cursor format");
+	const iso = since.slice(0, idx);
+	const idHex = since.slice(idx + 1);
+	const sortValue = new Date(iso);
+	if (Number.isNaN(sortValue.getTime())) {
+		throw new CursorError("invalid cursor timestamp");
+	}
+	if (!ObjectId.isValid(idHex)) {
+		throw new CursorError("invalid cursor id");
+	}
+	return { sortValue, id: new ObjectId(idHex) };
+}
+
+export function parseLimit(limit: string | undefined): number {
+	if (!limit) return DEFAULT_LIMIT;
+	const n = Number.parseInt(limit, 10);
+	if (Number.isNaN(n) || n < 1) {
+		throw new CursorError("invalid limit");
+	}
+	return Math.min(n, MAX_LIMIT);
+}
+
+export function cursorFilter(
+	sortField: string,
+	cursor: Cursor | null,
+): Record<string, unknown> {
+	if (!cursor) return {};
+	return {
+		$or: [
+			{ [sortField]: { $gt: cursor.sortValue } },
+			{ [sortField]: cursor.sortValue, _id: { $gt: cursor.id } },
+		],
+	};
+}
+
+export function encodeCursor(sortValue: Date, id: ObjectId): string {
+	return `${sortValue.toISOString()},${id.toHexString()}`;
+}

--- a/apps/manager/server/src/routes/data.ts
+++ b/apps/manager/server/src/routes/data.ts
@@ -7,6 +7,14 @@
 import { Elysia, t } from "elysia";
 import { authMiddleware } from "../lib/auth-middleware";
 import {
+	type Cursor,
+	CursorError,
+	cursorFilter,
+	encodeCursor,
+	parseCursor,
+	parseLimit,
+} from "../lib/cursor";
+import {
 	getChatMessagesCollection,
 	getConfigsCollection,
 	getEventsCollection,
@@ -15,17 +23,37 @@ import {
 	getWorkspaceDocumentsCollection,
 } from "../lib/db";
 
+const paginationQuerySchema = t.Object({
+	since: t.Optional(t.String()),
+	limit: t.Optional(t.String()),
+});
+
+type PaginationQuery = { since?: string; limit?: string };
+
+function parsePagination(
+	query: PaginationQuery,
+): { cursor: Cursor | null; limit: number } | CursorError {
+	try {
+		return {
+			cursor: parseCursor(query.since),
+			limit: parseLimit(query.limit),
+		};
+	} catch (err) {
+		if (err instanceof CursorError) return err;
+		throw err;
+	}
+}
+
 export const dataRoutes = new Elysia({ prefix: "/data" })
 	.use(authMiddleware)
 	.get(
 		"/:configId/sessions",
-		async ({ params: { configId }, set, user }) => {
+		async ({ params: { configId }, query, set, user }) => {
 			if (!user) {
 				set.status = 401;
 				return { error: "unauthorized", message: "Not authenticated" };
 			}
 
-			// Verify ownership
 			const configsCollection = await getConfigsCollection();
 			const config = await configsCollection.findOne({ configId });
 			if (!config) {
@@ -40,10 +68,21 @@ export const dataRoutes = new Elysia({ prefix: "/data" })
 				};
 			}
 
+			const pag = parsePagination(query);
+			if (pag instanceof CursorError) {
+				set.status = 400;
+				return { error: "bad_request", message: pag.message };
+			}
+			const { cursor, limit } = pag;
+
 			const sessionsCollection = await getSessionsCollection();
+			const filter = cursor
+				? { configId, ...cursorFilter("createdAt", cursor) }
+				: { configId };
 			const sessions = await sessionsCollection
-				.find({ configId })
-				.sort({ createdAt: 1 })
+				.find(filter)
+				.sort({ createdAt: 1, _id: 1 })
+				.limit(limit)
 				.toArray();
 
 			const exportData = sessions.map((session) => ({
@@ -59,23 +98,27 @@ export const dataRoutes = new Elysia({ prefix: "/data" })
 				endedAt: session.endedAt ?? null,
 			}));
 
-			return { sessions: exportData };
+			const last = sessions.at(-1);
+			const nextCursor =
+				sessions.length === limit && last?.createdAt && last._id
+					? encodeCursor(last.createdAt, last._id)
+					: null;
+
+			return { sessions: exportData, nextCursor };
 		},
 		{
-			params: t.Object({
-				configId: t.String(),
-			}),
+			params: t.Object({ configId: t.String() }),
+			query: paginationQuerySchema,
 		},
 	)
 	.get(
 		"/:configId/events",
-		async ({ params: { configId }, set, user }) => {
+		async ({ params: { configId }, query, set, user }) => {
 			if (!user) {
 				set.status = 401;
 				return { error: "unauthorized", message: "Not authenticated" };
 			}
 
-			// Verify ownership
 			const configsCollection = await getConfigsCollection();
 			const config = await configsCollection.findOne({ configId });
 			if (!config) {
@@ -90,10 +133,21 @@ export const dataRoutes = new Elysia({ prefix: "/data" })
 				};
 			}
 
+			const pag = parsePagination(query);
+			if (pag instanceof CursorError) {
+				set.status = 400;
+				return { error: "bad_request", message: pag.message };
+			}
+			const { cursor, limit } = pag;
+
 			const eventsCollection = await getEventsCollection();
+			const filter = cursor
+				? { configId, ...cursorFilter("createdAt", cursor) }
+				: { configId };
 			const events = await eventsCollection
-				.find({ configId })
-				.sort({ createdAt: 1 })
+				.find(filter)
+				.sort({ createdAt: 1, _id: 1 })
+				.limit(limit)
 				.toArray();
 
 			const exportData = events.map((event) => ({
@@ -107,23 +161,27 @@ export const dataRoutes = new Elysia({ prefix: "/data" })
 				createdAt: event.createdAt?.toISOString() ?? null,
 			}));
 
-			return { events: exportData };
+			const last = events.at(-1);
+			const nextCursor =
+				events.length === limit && last?.createdAt && last._id
+					? encodeCursor(last.createdAt, last._id)
+					: null;
+
+			return { events: exportData, nextCursor };
 		},
 		{
-			params: t.Object({
-				configId: t.String(),
-			}),
+			params: t.Object({ configId: t.String() }),
+			query: paginationQuerySchema,
 		},
 	)
 	.get(
 		"/:configId/chat-messages",
-		async ({ params: { configId }, set, user }) => {
+		async ({ params: { configId }, query, set, user }) => {
 			if (!user) {
 				set.status = 401;
 				return { error: "unauthorized", message: "Not authenticated" };
 			}
 
-			// Verify ownership
 			const configsCollection = await getConfigsCollection();
 			const config = await configsCollection.findOne({ configId });
 			if (!config) {
@@ -138,10 +196,21 @@ export const dataRoutes = new Elysia({ prefix: "/data" })
 				};
 			}
 
+			const pag = parsePagination(query);
+			if (pag instanceof CursorError) {
+				set.status = 400;
+				return { error: "bad_request", message: pag.message };
+			}
+			const { cursor, limit } = pag;
+
 			const chatCollection = await getChatMessagesCollection();
+			const filter = cursor
+				? { configId, ...cursorFilter("createdAt", cursor) }
+				: { configId };
 			const messages = await chatCollection
-				.find({ configId })
-				.sort({ createdAt: 1 })
+				.find(filter)
+				.sort({ createdAt: 1, _id: 1 })
+				.limit(limit)
 				.toArray();
 
 			const exportData = messages.map((msg) => ({
@@ -153,17 +222,22 @@ export const dataRoutes = new Elysia({ prefix: "/data" })
 				createdAt: msg.createdAt?.toISOString() ?? null,
 			}));
 
-			return { messages: exportData };
+			const last = messages.at(-1);
+			const nextCursor =
+				messages.length === limit && last?.createdAt && last._id
+					? encodeCursor(last.createdAt, last._id)
+					: null;
+
+			return { messages: exportData, nextCursor };
 		},
 		{
-			params: t.Object({
-				configId: t.String(),
-			}),
+			params: t.Object({ configId: t.String() }),
+			query: paginationQuerySchema,
 		},
 	)
 	.get(
 		"/:configId/groups",
-		async ({ params: { configId }, set, user }) => {
+		async ({ params: { configId }, query, set, user }) => {
 			if (!user) {
 				set.status = 401;
 				return { error: "unauthorized", message: "Not authenticated" };
@@ -183,10 +257,21 @@ export const dataRoutes = new Elysia({ prefix: "/data" })
 				};
 			}
 
+			const pag = parsePagination(query);
+			if (pag instanceof CursorError) {
+				set.status = 400;
+				return { error: "bad_request", message: pag.message };
+			}
+			const { cursor, limit } = pag;
+
 			const groupsCollection = await getGroupsCollection();
+			const filter = cursor
+				? { configId, ...cursorFilter("matchedAt", cursor) }
+				: { configId };
 			const groups = await groupsCollection
-				.find({ configId })
-				.sort({ matchedAt: 1 })
+				.find(filter)
+				.sort({ matchedAt: 1, _id: 1 })
+				.limit(limit)
 				.toArray();
 
 			// Explode memberSessionIds → one row per (group, session)
@@ -201,17 +286,22 @@ export const dataRoutes = new Elysia({ prefix: "/data" })
 				})),
 			);
 
-			return { groups: exportData };
+			const last = groups.at(-1);
+			const nextCursor =
+				groups.length === limit && last?.matchedAt && last._id
+					? encodeCursor(last.matchedAt, last._id)
+					: null;
+
+			return { groups: exportData, nextCursor };
 		},
 		{
-			params: t.Object({
-				configId: t.String(),
-			}),
+			params: t.Object({ configId: t.String() }),
+			query: paginationQuerySchema,
 		},
 	)
 	.get(
 		"/:configId/survey-responses",
-		async ({ params: { configId }, set, user }) => {
+		async ({ params: { configId }, query, set, user }) => {
 			if (!user) {
 				set.status = 401;
 				return { error: "unauthorized", message: "Not authenticated" };
@@ -231,16 +321,29 @@ export const dataRoutes = new Elysia({ prefix: "/data" })
 				};
 			}
 
+			const pag = parsePagination(query);
+			if (pag instanceof CursorError) {
+				set.status = 400;
+				return { error: "bad_request", message: pag.message };
+			}
+			const { cursor, limit } = pag;
+
+			const baseOr = [
+				{ componentType: "survey" },
+				{ componentType: "paged_survey", "data.status": "completed" },
+			];
+			const filter = cursor
+				? {
+						configId,
+						$and: [{ $or: baseOr }, cursorFilter("createdAt", cursor)],
+					}
+				: { configId, $or: baseOr };
+
 			const eventsCollection = await getEventsCollection();
 			const events = await eventsCollection
-				.find({
-					configId,
-					$or: [
-						{ componentType: "survey" },
-						{ componentType: "paged_survey", "data.status": "completed" },
-					],
-				})
-				.sort({ createdAt: 1 })
+				.find(filter)
+				.sort({ createdAt: 1, _id: 1 })
+				.limit(limit)
 				.toArray();
 
 			const exportData = events.map((event) => ({
@@ -251,17 +354,22 @@ export const dataRoutes = new Elysia({ prefix: "/data" })
 				data: event.data ?? {},
 			}));
 
-			return { surveyResponses: exportData };
+			const last = events.at(-1);
+			const nextCursor =
+				events.length === limit && last?.createdAt && last._id
+					? encodeCursor(last.createdAt, last._id)
+					: null;
+
+			return { surveyResponses: exportData, nextCursor };
 		},
 		{
-			params: t.Object({
-				configId: t.String(),
-			}),
+			params: t.Object({ configId: t.String() }),
+			query: paginationQuerySchema,
 		},
 	)
 	.get(
 		"/:configId/workspace-documents",
-		async ({ params: { configId }, set, user }) => {
+		async ({ params: { configId }, query, set, user }) => {
 			if (!user) {
 				set.status = 401;
 				return { error: "unauthorized", message: "Not authenticated" };
@@ -281,10 +389,21 @@ export const dataRoutes = new Elysia({ prefix: "/data" })
 				};
 			}
 
+			const pag = parsePagination(query);
+			if (pag instanceof CursorError) {
+				set.status = 400;
+				return { error: "bad_request", message: pag.message };
+			}
+			const { cursor, limit } = pag;
+
 			const wsCollection = await getWorkspaceDocumentsCollection();
+			const filter = cursor
+				? { configId, ...cursorFilter("updatedAt", cursor) }
+				: { configId };
 			const documents = await wsCollection
-				.find({ configId })
-				.sort({ updatedAt: 1 })
+				.find(filter)
+				.sort({ updatedAt: 1, _id: 1 })
+				.limit(limit)
 				.toArray();
 
 			const exportData = documents.map((doc) => ({
@@ -297,11 +416,16 @@ export const dataRoutes = new Elysia({ prefix: "/data" })
 				updatedAt: doc.updatedAt?.toISOString() ?? null,
 			}));
 
-			return { workspaceDocuments: exportData };
+			const last = documents.at(-1);
+			const nextCursor =
+				documents.length === limit && last?.updatedAt && last._id
+					? encodeCursor(last.updatedAt, last._id)
+					: null;
+
+			return { workspaceDocuments: exportData, nextCursor };
 		},
 		{
-			params: t.Object({
-				configId: t.String(),
-			}),
+			params: t.Object({ configId: t.String() }),
+			query: paginationQuerySchema,
 		},
 	);


### PR DESCRIPTION
## Summary

Item 2 from #99. Add `?since=<sortField-ISO>,<_id-hex>` cursor + `?limit=` (default 5000, max 20000) to all six `/data/:configId/*` endpoints, returning `nextCursor: string | null`. CLI loops each endpoint until `nextCursor === null`. Output file format unchanged.

Resumable exports, bounded server memory per request, no breaking change from the CLI user's perspective.

## What's in here

- New helper: `apps/manager/server/src/lib/cursor.ts` — parse/build cursor filter, parse limit, encode cursor.
- All six endpoints in `data.ts` take `?since=&?limit=`, return `nextCursor`. Sort gains `_id` tiebreaker.
  - 4 use `createdAt`: `/sessions`, `/events`, `/chat-messages`, `/survey-responses`
  - `/groups` uses `matchedAt`; `/workspace-documents` uses `updatedAt`
  - Existing `{ configId, sortField }` indexes already serve every case.
- CLI gains `fetchAllPages<T>()` helper used by `exportData` for all six endpoints.

## Behavior

- **CLI users**: unchanged — same files, same content.
- **Direct HTTP callers**: gain `?since=` and `?limit=` params and a `nextCursor` field in the response. If a caller does not pass `?limit=` and silently ignores `nextCursor`, they get only the first 5000 rows. Confirmed with the user that the CLI is the only consumer today.
- **Bad cursor or limit**: 400 with `{ error: "bad_request", message }`.

## Verification

Cursor equivalence checked against prod with page size 100, comparing concatenated paginated results to the un-paginated query for every config:

| collection         | configs | total docs | mismatches |
|--------------------|---------|------------|------------|
| sessions           | 174     | 1,828      | 0          |
| events             | 143     | 21,964     | 0          |
| chat_messages      | 130     | 43,594     | 0          |
| groups             | 31      | 40         | 0          |
| events ($or filter for survey-responses) | 140 | 13,307 | 0 |
| workspace_documents | 0      | 0          | 0 (no data in prod) |

Type check + biome lint clean.

## Test plan

- [ ] CI
- [ ] Run `pairit data export <configId>` against a config with thousands of events; verify output files match a known-good baseline
- [ ] Hit one endpoint directly with `?limit=1` and follow `nextCursor` 3-5 times; confirm the rows form a continuous sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)