### PR TITLE
Bump CLI version to 0.1.8

### DIFF
--- a/apps/manager/cli/package.json
+++ b/apps/manager/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pairit",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "CLI for the Pairit behavioral science experiment platform",
   "type": "module",
   "bin": {

--- a/apps/manager/cli/src/index.ts
+++ b/apps/manager/cli/src/index.ts
@@ -30,7 +30,7 @@ const program = new Command();
 program
 	.name("pairit")
 	.description("CLI for Pairit experiment configs")
-	.version("0.1.7");
+	.version("0.1.8");
 
 program
 	.command("login")


### PR DESCRIPTION
Patch bump to release cursor pagination (#105) and sequential export (#106) on npm.

User-visible changes since 0.1.7:
- `pairit data export` now follows server cursors automatically — works with arbitrarily large configs without timing out
- Peak CLI memory drops from sum-of-six-endpoints to max(endpoint)
- Output file format unchanged; existing workflows keep working

After merge, run `npm publish` from `apps/manager/cli/` to release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)