### PR TITLE
Refresh manager web pages to match lab UI style

### DIFF
--- a/apps/manager/server/src/index.ts
+++ b/apps/manager/server/src/index.ts
@@ -227,40 +227,27 @@ app
 			}
 		}
 
-		const content = `
-        <div class="card">
-            <h1>
-                <svg class="icon" viewBox="0 0 24 24" style="color: var(--emerald-600); width: 32px; height: 32px;">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                Login Successful
-            </h1>
-
-            ${
-							redirectUrl
-								? `
-                <p>Redirecting you back to the CLI...</p>
-                <div style="margin-top: 1rem; font-size: 0.875rem; color: var(--slate-600);">
-                    If you are not redirected, <a href="${redirectUrl}">click here</a>.
-                </div>
-            `
-								: manual && authCode
-									? `
-                <p>Copy this one-time authorization code into your CLI. It expires in 60 seconds.</p>
-                <div class="token-box" id="auth-code">${authCode}</div>
-                <div style="display:flex; gap:0.75rem; width:100%; flex-direction:column;">
-                    <button onclick="copyCode()" class="btn btn-blue">Copy Code</button>
-                    <button onclick="window.close()" class="btn btn-primary">Close Window</button>
-                </div>
-            `
-									: `
-                <p>You have successfully authenticated. You can now close this window and return to your CLI.</p>
-                <div style="margin-top: 1.5rem;">
-                    <button onclick="window.close()" class="btn btn-blue">Close Window</button>
-                </div>
-            `
-						}
-        </div>`;
+		const content = redirectUrl
+			? `
+            <h1>Signed in</h1>
+            <p class="subtitle">Returning you to the CLI…</p>
+            <p class="footnote">Nothing happening? <a href="${redirectUrl}">Retry the handoff.</a></p>`
+			: manual && authCode
+				? `
+            <h1>One-time code</h1>
+            <p class="subtitle">Paste this into your terminal. It expires in 60 seconds.</p>
+            <p class="token-meta">Authorization code</p>
+            <div class="token" id="auth-code">${authCode}</div>
+            <div class="btn-row">
+                <button onclick="copyCode()" class="btn btn--primary">Copy code</button>
+                <button onclick="window.close()" class="btn btn--ghost">Close window</button>
+            </div>`
+				: `
+            <h1>Signed in</h1>
+            <p class="subtitle">You're authenticated. You can close this window and return to your CLI.</p>
+            <div class="btn-row">
+                <button onclick="window.close()" class="btn btn--ghost">Close window</button>
+            </div>`;
 
 		const scriptContent = `
         <script>
@@ -285,7 +272,7 @@ app
 
 		return new Response(
 			renderPage({
-				title: "Login Successful",
+				title: "Signed in",
 				content,
 				scripts: scriptContent,
 			}),
@@ -299,28 +286,35 @@ app
 	.get("/access-denied", () => {
 		const contact = getContactEmail();
 		const content = `
-        <div class="card">
             <h1>Access denied</h1>
-            <p>This Pairit manager is invite-only. Your Google account isn't on the allowlist yet.</p>
-            <p>Email <a href="mailto:${contact}">${contact}</a> to request access.</p>
-            <a href="/" class="btn btn-secondary">Back to home</a>
-        </div>`;
-		return new Response(renderPage({ title: "Access denied", content }), {
-			headers: { "content-type": "text/html" },
-			status: 403,
-		});
+            <p class="subtitle">Pairit Manager is invite-only. Your Google account isn't on the allowlist for this instance.</p>
+            <div class="btn-row">
+                <a href="mailto:${contact}" class="btn btn--primary">Request access</a>
+                <a href="/" class="btn btn--ghost">Back to home</a>
+            </div>
+            <p class="footnote">Contact <a href="mailto:${contact}">${contact}</a></p>`;
+		return new Response(
+			renderPage({
+				title: "Access denied",
+				content,
+			}),
+			{
+				headers: { "content-type": "text/html" },
+				status: 403,
+			},
+		);
 	})
 	.get("/login", ({ query }) => {
 		const manual = query.manual === "1";
 		const content = `
-        <div class="card">
-            <h1>Pairit CLI Login</h1>
-            <p>${manual ? "Sign in with Google to get a one-time authorization code for your CLI." : "Click the button below to sign in with Google."}</p>
-            <button onclick="login()" class="btn btn-blue">
-                <svg class="icon" viewBox="0 0 24 24"><path d="M17.788 5.108A9 9 0 1021 12h-8"></path></svg>
-                Sign in with Google
-            </button>
-        </div>`;
+            <h1>Sign in</h1>
+            <p class="subtitle">${manual ? "Authenticate with your allowlisted Google account. We'll hand off a one-time code your CLI can exchange for a session." : "Authenticate with your allowlisted Google account. Your CLI will resume automatically when the handoff completes."}</p>
+            <div class="btn-row">
+                <button onclick="login()" class="btn btn--primary">
+                    Continue with Google
+                </button>
+            </div>
+            <p class="footnote">Not on the allowlist? Ask your operator for an invite.</p>`;
 
 		const scriptContent = `
         <script>
@@ -367,7 +361,7 @@ app
 
 		return new Response(
 			renderPage({
-				title: "Pairit CLI Login",
+				title: "Sign in",
 				content,
 				scripts: scriptContent,
 			}),
@@ -378,39 +372,22 @@ app
 	})
 	.get("/", () => {
 		const content = `
-        <section class="hero">
             <h1>Pairit Manager</h1>
-            <p class="subtitle">API server for the Pairit CLI.</p>
-        </section>
-
-        <div class="grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem;">
-            <div class="card">
-                <h2>
-                    <svg class="icon" viewBox="0 0 24 24"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg>
-                    CLI Login
-                </h2>
-                <p>Authenticate the Pairit CLI to upload configs and export data.</p>
-                <a href="/login" class="btn btn-primary">Login with Google</a>
-            </div>
-
-            <div class="card">
-                <h2>
-                    <svg class="icon" viewBox="0 0 24 24"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"></path></svg>
-                    Documentation
-                </h2>
-                <p>Learn how to create experiments and use the CLI.</p>
-                <a href="https://pairium.github.io/pairit/" class="btn btn-secondary" target="_blank">Read the docs</a>
-            </div>
-
-            <div class="card">
-                <h2>
-                    <svg class="icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"></circle><line x1="14.31" y1="8" x2="20.05" y2="17.94"></line><line x1="9.69" y1="8" x2="21.17" y2="8"></line><line x1="7.38" y1="12" x2="13.12" y2="2.06"></line><line x1="9.69" y1="16" x2="3.95" y2="6.06"></line><line x1="14.31" y1="16" x2="2.83" y2="16"></line><line x1="16.62" y1="12" x2="10.88" y2="21.94"></line></svg>
-                    Lab
-                </h2>
-                <p>Run experiments with participants.</p>
-                <a href="${LAB_URL}" class="btn btn-secondary">Open Lab</a>
-            </div>
-        </div>`;
+            <p class="subtitle">The API server for the Pairit CLI. Sign in below, or head to the lab to run experiments.</p>
+            <nav class="actions" aria-label="Primary destinations">
+                <a href="/login" class="action">
+                    <span class="label">Sign in to the CLI</span>
+                    <span class="arrow" aria-hidden="true">→</span>
+                </a>
+                <a href="https://pairium.github.io/pairit/" class="action" target="_blank" rel="noopener">
+                    <span class="label">Documentation</span>
+                    <span class="arrow" aria-hidden="true">→</span>
+                </a>
+                <a href="${LAB_URL}" class="action">
+                    <span class="label">Open the lab</span>
+                    <span class="arrow" aria-hidden="true">→</span>
+                </a>
+            </nav>`;
 
 		return new Response(
 			renderPage({

--- a/apps/manager/server/src/lib/html.ts
+++ b/apps/manager/server/src/lib/html.ts
@@ -4,244 +4,254 @@ export interface PageOptions {
 	scripts?: string;
 }
 
+const GLOBAL_CSS = `
+:root {
+    --slate-50: #f8fafc;
+    --slate-100: #f1f5f9;
+    --slate-200: #e2e8f0;
+    --slate-300: #cbd5e1;
+    --slate-500: #64748b;
+    --slate-600: #475569;
+    --slate-700: #334155;
+    --slate-900: #0f172a;
+    --red-50: #fef2f2;
+    --red-600: #dc2626;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+html, body { background: var(--slate-50); }
+
+body {
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+        "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    color: var(--slate-900);
+    font-size: 15px;
+    line-height: 1.55;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+a { color: var(--slate-900); text-decoration: underline; text-underline-offset: 3px; text-decoration-color: var(--slate-300); }
+a:hover { text-decoration-color: var(--slate-900); }
+
+.shell {
+    min-height: 100vh;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+}
+
+.header, .footer {
+    padding: 1rem 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.header {
+    border-bottom: 1px solid var(--slate-200);
+    background: rgba(255, 255, 255, 0.7);
+    backdrop-filter: blur(8px);
+}
+
+.brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    color: var(--slate-900);
+    font-weight: 600;
+    font-size: 0.95rem;
+    text-decoration: none;
+}
+.brand-mark {
+    width: 18px; height: 18px;
+    stroke: currentColor; stroke-width: 1.8;
+    stroke-linecap: round; stroke-linejoin: round;
+    fill: none;
+}
+
+.tag {
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    color: var(--slate-500);
+    padding: 0.25rem 0.55rem;
+    border: 1px solid var(--slate-200);
+    border-radius: 999px;
+    background: white;
+}
+
+.footer {
+    border-top: 1px solid var(--slate-200);
+    font-size: 12px;
+    color: var(--slate-500);
+    background: white;
+}
+.footer a { color: var(--slate-500); text-decoration-color: var(--slate-300); }
+.footer a:hover { color: var(--slate-900); }
+
+.main {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 3rem 1.5rem;
+}
+
+.card {
+    width: 100%;
+    max-width: 28rem;
+    background: white;
+    border: 1px solid var(--slate-200);
+    border-radius: 1rem;
+    padding: 2.25rem;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+h1 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: -0.015em;
+    color: var(--slate-900);
+    margin-bottom: 0.5rem;
+}
+
+.subtitle {
+    color: var(--slate-600);
+    font-size: 0.95rem;
+    line-height: 1.55;
+    margin-bottom: 1.75rem;
+}
+
+.actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.action {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.875rem 1rem;
+    border: 1px solid var(--slate-200);
+    border-radius: 0.625rem;
+    color: var(--slate-900);
+    text-decoration: none;
+    background: white;
+    transition: background 0.15s ease, border-color 0.15s ease;
+}
+.action:hover {
+    background: var(--slate-50);
+    border-color: var(--slate-300);
+}
+.action .label { font-size: 0.95rem; font-weight: 500; }
+.action .arrow {
+    color: var(--slate-500);
+    transition: transform 0.15s ease, color 0.15s ease;
+}
+.action:hover .arrow { color: var(--slate-900); transform: translateX(2px); }
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.625rem 1rem;
+    font-size: 0.9rem;
+    font-weight: 500;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    text-decoration: none;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    border: 1px solid transparent;
+    font-family: inherit;
+}
+.btn--primary {
+    background: var(--slate-900);
+    color: white;
+}
+.btn--primary:hover { background: #1e293b; }
+.btn--ghost {
+    background: white;
+    color: var(--slate-900);
+    border-color: var(--slate-200);
+}
+.btn--ghost:hover { background: var(--slate-50); border-color: var(--slate-300); }
+.btn[disabled] { opacity: 0.55; cursor: not-allowed; }
+
+.btn-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.token {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, "Courier New", monospace;
+    font-size: 0.85rem;
+    word-break: break-all;
+    padding: 0.875rem 1rem;
+    background: var(--slate-50);
+    border: 1px solid var(--slate-200);
+    border-radius: 0.5rem;
+    color: var(--slate-900);
+    margin-bottom: 1rem;
+}
+.token.error { color: var(--red-600); border-color: var(--red-600); background: var(--red-50); }
+
+.token-meta {
+    font-size: 11px;
+    color: var(--slate-500);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 0.5rem;
+}
+
+.footnote {
+    color: var(--slate-500);
+    font-size: 0.8rem;
+    margin-top: 1.25rem;
+}
+
+.icon { width: 18px; height: 18px; stroke: currentColor; stroke-width: 2; fill: none; }
+`;
+
+function brandMarkSvg(): string {
+	return `<svg class="brand-mark" viewBox="0 0 24 24" aria-hidden="true"><path d="M16 7h.01"/><path d="M3.4 18H12a8 8 0 0 0 8-8V7a4 4 0 0 0-7.28-2.3L2 20"/><path d="m20 7 2 .5-2 .5"/><path d="M10 18v3"/><path d="M14 17.75V21"/><path d="M7 18a6 6 0 0 0 3.84-10.61"/></svg>`;
+}
+
 export function renderPage({ title, content, scripts = "" }: PageOptions) {
 	return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>${title}</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <style>
-        :root {
-            --slate-50: #f8fafc;
-            --slate-100: #f1f5f9;
-            --slate-200: #e2e8f0;
-            --slate-600: #475569;
-            --slate-900: #0f172a;
-            --blue-600: #2563eb;
-            --blue-700: #1d4ed8;
-            --emerald-600: #059669;
-            --red-600: #dc2626;
-            --red-50: #fef2f2;
-        }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
-        body {
-            font-family: 'Inter', -apple-system, system-ui, sans-serif;
-            background-color: var(--slate-50);
-            color: var(--slate-900);
-            line-height: 1.5;
-            min-height: 100vh;
-            display: flex;
-            flex-direction: column;
-        }
-
-        .header {
-            background: rgba(255, 255, 255, 0.8);
-            backdrop-filter: blur(8px);
-            border-bottom: 1px solid var(--slate-200);
-            padding: 1rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 10;
-        }
-
-        .header-content {
-            max-width: 1024px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 0.75rem;
-        }
-
-        .logo {
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-            font-weight: 700;
-            font-size: 1.25rem;
-            color: var(--slate-900);
-            text-decoration: none;
-        }
-
-        .container {
-            max-width: 1024px;
-            margin: 0 auto;
-            padding: 4rem 1.5rem;
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            text-align: center;
-            width: 100%;
-        }
-
-        .hero {
-            margin-bottom: 3rem;
-        }
-
-        h1 {
-            font-size: 2.5rem;
-            font-weight: 700;
-            letter-spacing: -0.025em;
-            margin-bottom: 1rem;
-            color: var(--slate-900);
-        }
-
-        .subtitle {
-            font-size: 1.125rem;
-            color: var(--slate-600);
-            max-width: 600px;
-            margin: 0 auto;
-        }
-
-        .card {
-            background: white;
-            border: 1px solid var(--slate-200);
-            border-radius: 1.5rem;
-            padding: 3rem;
-            transition: all 0.2s ease;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            max-width: 450px;
-            width: 100%;
-            margin: 0 auto;
-        }
-
-        .card:hover {
-            border-color: var(--slate-200);
-            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
-            transform: translateY(-2px);
-        }
-
-        .card h2 {
-            font-size: 1.5rem;
-            font-weight: 600;
-            margin-bottom: 1rem;
-            display: flex;
-            align-items: center;
-            gap: 0.75rem;
-        }
-
-        .card p {
-            color: var(--slate-600);
-            font-size: 1rem;
-            margin-bottom: 2.5rem;
-        }
-
-        .btn {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            gap: 0.5rem;
-            padding: 0.75rem 1.5rem;
-            border-radius: 0.75rem;
-            font-weight: 600;
-            font-size: 1rem;
-            text-decoration: none;
-            transition: all 0.2s;
-            cursor: pointer;
-            border: none;
-            width: 100%;
-        }
-
-        .btn:disabled {
-            opacity: 0.7;
-            cursor: not-allowed;
-            background-color: var(--slate-600);
-        }
-
-        .btn-primary {
-            background-color: var(--slate-900);
-            color: white;
-        }
-
-        .btn-primary:hover:not(:disabled) {
-            background-color: #1e293b;
-        }
-
-        .btn-blue {
-            background-color: var(--blue-600);
-            color: white;
-        }
-
-        .btn-blue:hover:not(:disabled) {
-            background-color: var(--blue-700);
-        }
-
-        .token-box {
-            background: var(--slate-100);
-            color: var(--slate-900);
-            padding: 1rem;
-            border-radius: 0.5rem;
-            font-family: monospace;
-            word-break: break-all;
-            margin-bottom: 1.5rem;
-            border: 1px solid var(--slate-200);
-            font-size: 0.875rem;
-            width: 100%;
-        }
-
-        .token-box.error {
-            background: var(--red-50);
-            color: var(--red-600);
-            border-color: var(--red-600);
-        }
-
-        .footer {
-            border-top: 1px solid var(--slate-200);
-            padding: 1.5rem;
-            background: white;
-            margin-top: auto;
-        }
-
-        .footer-content {
-            max-width: 1024px;
-            margin: 0 auto;
-            font-size: 0.75rem;
-            color: var(--slate-600);
-            display: flex;
-            justify-content: space-between;
-        }
-
-        .icon {
-            width: 24px;
-            height: 24px;
-            stroke: currentColor;
-            stroke-width: 2;
-            fill: none;
-        }
-
-        a { color: var(--blue-600); text-decoration: none; }
-        a:hover { text-decoration: underline; }
-    </style>
+    <title>${title} — Pairit Manager</title>
+    <style>${GLOBAL_CSS}</style>
 </head>
 <body>
-    <header class="header">
-        <div class="header-content">
-            <a href="/" class="logo">
-                <svg class="icon" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M16 7h.01"/><path d="M3.4 18H12a8 8 0 0 0 8-8V7a4 4 0 0 0-7.28-2.3L2 20"/><path d="m20 7 2 .5-2 .5"/><path d="M10 18v3"/><path d="M14 17.75V21"/><path d="M7 18a6 6 0 0 0 3.84-10.61"/></svg>
-                Pairit Manager
+    <div class="shell">
+        <header class="header">
+            <a href="/" class="brand">
+                ${brandMarkSvg()}
+                <span>Pairit Manager</span>
             </a>
-        </div>
-    </header>
+            <span class="tag">Invite-only</span>
+        </header>
 
-    <main class="container">
-        ${content}
-    </main>
+        <main class="main">
+            <div class="card">
+                ${content}
+            </div>
+        </main>
 
-    <footer class="footer">
-        <div class="footer-content">
-            <span>Pairit Manager · Management Console</span>
-            <span>&copy; 2025 Pairium AI</span>
-        </div>
-    </footer>
+        <footer class="footer">
+            <span>Pairit Manager</span>
+            <span>&copy; Pairium AI</span>
+        </footer>
+    </div>
     ${scripts}
 </body>
 </html>`;


### PR DESCRIPTION
## Summary
- Rebuild the manager's four public HTML pages (landing, `/login`, `/login-success`, `/access-denied`) on the same shadcn-leaning vocabulary the lab uses: slate-50 canvas, single white card, system sans, neutral primary/ghost buttons, simple link rows.
- Trim the bespoke inline CSS down to a small, neutral palette and drop the marketing-card grid in favor of a single focused card per page.

## Test plan
- [ ] Visit `/` — landing card with three link rows (sign-in, docs, lab) renders cleanly.
- [ ] Visit `/login` and `/login?manual=1` — sign-in card with "Continue with Google" button.
- [ ] Sign in to confirm `/login-success` renders correctly in all three states (auto-redirect, one-time code, close).
- [ ] Visit `/access-denied` with a non-allowlisted account — denied card with request-access + back-to-home buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)