### PR TITLE
Fix MongoDB sort memory limit on data export

### DIFF
--- a/apps/lab/server/src/lib/db.ts
+++ b/apps/lab/server/src/lib/db.ts
@@ -75,7 +75,7 @@ export async function ensureIndexes(): Promise<void> {
 		.createIndex({ sessionId: 1, createdAt: 1 });
 	await database
 		.collection("events")
-		.createIndex({ configId: 1, createdAt: 1 });
+		.createIndex({ configId: 1, createdAt: 1, _id: 1 });
 	await database
 		.collection("events")
 		.createIndex({ idempotencyKey: 1 }, { unique: true, sparse: true });
@@ -94,7 +94,7 @@ export async function ensureIndexes(): Promise<void> {
 		.createIndex({ groupId: 1, createdAt: 1 });
 	await database
 		.collection("chat_messages")
-		.createIndex({ configId: 1, createdAt: 1 });
+		.createIndex({ configId: 1, createdAt: 1, _id: 1 });
 	await database
 		.collection("chat_messages")
 		.createIndex({ idempotencyKey: 1 }, { unique: true, sparse: true });
@@ -104,11 +104,11 @@ export async function ensureIndexes(): Promise<void> {
 		.createIndex({ groupId: 1 }, { unique: true });
 	await database
 		.collection("groups")
-		.createIndex({ configId: 1, matchedAt: 1 });
+		.createIndex({ configId: 1, matchedAt: 1, _id: 1 });
 
 	await database
 		.collection("sessions")
-		.createIndex({ configId: 1, createdAt: 1 });
+		.createIndex({ configId: 1, createdAt: 1, _id: 1 });
 
 	// Session resumption indexes
 	// OAuth user lookup: find sessions by userId + configId
@@ -129,7 +129,7 @@ export async function ensureIndexes(): Promise<void> {
 		.createIndex({ groupId: 1 }, { unique: true });
 	await database
 		.collection("workspace_documents")
-		.createIndex({ configId: 1, updatedAt: 1 });
+		.createIndex({ configId: 1, updatedAt: 1, _id: 1 });
 
 	console.log("[DB] All indexes ensured");
 }

--- a/scripts/drop-redundant-export-indexes.ts
+++ b/scripts/drop-redundant-export-indexes.ts
@@ -1,0 +1,102 @@
+/**
+ * One-time migration: drop the old {configId, sortField} compound indexes
+ * that have been replaced by {configId, sortField, _id} (defined in
+ * apps/lab/server/src/lib/db.ts). The new indexes are a strict superset:
+ * any query the old index served can be served by the new one.
+ *
+ * Refuses to drop an old index unless its replacement is present, so it
+ * is safe to run before/independently of the lab-server redeploy.
+ *
+ * Safe to re-run.
+ *
+ * Usage:
+ *   bun --env-file=.env scripts/drop-redundant-export-indexes.ts
+ */
+
+import type { Document } from "mongodb";
+import { closeDB, connectDB } from "../packages/db";
+
+type Replacement = {
+	collection: string;
+	oldName: string;
+	oldKey: Document;
+	newKey: Document;
+};
+
+const REPLACEMENTS: Replacement[] = [
+	{
+		collection: "events",
+		oldName: "configId_1_createdAt_1",
+		oldKey: { configId: 1, createdAt: 1 },
+		newKey: { configId: 1, createdAt: 1, _id: 1 },
+	},
+	{
+		collection: "chat_messages",
+		oldName: "configId_1_createdAt_1",
+		oldKey: { configId: 1, createdAt: 1 },
+		newKey: { configId: 1, createdAt: 1, _id: 1 },
+	},
+	{
+		collection: "sessions",
+		oldName: "configId_1_createdAt_1",
+		oldKey: { configId: 1, createdAt: 1 },
+		newKey: { configId: 1, createdAt: 1, _id: 1 },
+	},
+	{
+		collection: "groups",
+		oldName: "configId_1_matchedAt_1",
+		oldKey: { configId: 1, matchedAt: 1 },
+		newKey: { configId: 1, matchedAt: 1, _id: 1 },
+	},
+	{
+		collection: "workspace_documents",
+		oldName: "configId_1_updatedAt_1",
+		oldKey: { configId: 1, updatedAt: 1 },
+		newKey: { configId: 1, updatedAt: 1, _id: 1 },
+	},
+];
+
+function keysEqual(a: Document, b: Document): boolean {
+	const ak = Object.keys(a);
+	const bk = Object.keys(b);
+	if (ak.length !== bk.length) return false;
+	return ak.every((k, i) => k === bk[i] && a[k] === b[k]);
+}
+
+async function main() {
+	const db = await connectDB();
+
+	for (const r of REPLACEMENTS) {
+		const indexes = (await db
+			.collection(r.collection)
+			.indexes()) as Document[];
+
+		const oldIdx = indexes.find((i) => keysEqual(i.key, r.oldKey));
+		const newIdx = indexes.find((i) => keysEqual(i.key, r.newKey));
+
+		if (!oldIdx) {
+			console.log(
+				`[${r.collection}] old index ${JSON.stringify(r.oldKey)} already gone — skipping`,
+			);
+			continue;
+		}
+		if (!newIdx) {
+			console.warn(
+				`[${r.collection}] replacement ${JSON.stringify(r.newKey)} not present — refusing to drop old index. Deploy lab-server first so ensureIndexes() builds it.`,
+			);
+			continue;
+		}
+
+		const dropName = oldIdx.name ?? r.oldName;
+		console.log(`[${r.collection}] dropping ${dropName}...`);
+		await db.collection(r.collection).dropIndex(dropName);
+		console.log(`[${r.collection}] dropped ${dropName}`);
+	}
+
+	await closeDB();
+}
+
+main().catch((err) => {
+	console.error("Migration failed:", err);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Data export endpoints sort by `{sortField, _id}` but the existing compound indexes only covered `{configId, sortField}`, forcing a blocking in-memory sort that exceeded Mongo's 32MB ceiling on configs with large event payloads (observed HTTP 500 during CLI export).
- Extend the five export-relevant indexes (events, chat_messages, sessions, groups, workspace_documents) to include `_id` so the sort is fully index-served (ESR rule).
- Add `scripts/drop-redundant-export-indexes.ts` to drop the now-redundant prefix indexes; refuses to drop unless the replacement is present, safe to re-run.

## Test plan
- [x] Lab-server deployed (`lab-00042`); `ensureIndexes()` built the new compound indexes on boot
- [x] Migration script run against Atlas; all five old prefix indexes dropped
- [ ] Re-run the failed CLI export for config `67e0474ed3e2` and confirm no more 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)