### PR TITLE
Hide matchmaking condition from participants

### DIFF
--- a/apps/lab/app/src/components/Matchmaking/MatchmakingPanel.tsx
+++ b/apps/lab/app/src/components/Matchmaking/MatchmakingPanel.tsx
@@ -16,8 +16,6 @@ export type MatchmakingPanelProps = {
 	targetCount: number;
 	timeoutSeconds: number;
 	elapsedSeconds: number;
-	groupId?: string;
-	treatment?: string;
 	onCancel?: () => void;
 };
 
@@ -27,8 +25,6 @@ export function MatchmakingPanel({
 	targetCount,
 	timeoutSeconds,
 	elapsedSeconds,
-	groupId,
-	treatment,
 	onCancel,
 }: MatchmakingPanelProps) {
 	const remainingSeconds = Math.max(0, timeoutSeconds - elapsedSeconds);
@@ -119,21 +115,6 @@ export function MatchmakingPanel({
 							You've been matched with other participants
 						</p>
 					</div>
-					{(groupId || treatment) && (
-						<div className="w-full rounded-lg bg-slate-50 p-3 text-sm">
-							{groupId && (
-								<p className="text-slate-600">
-									<span className="font-medium">Group:</span>{" "}
-									{groupId.slice(0, 8)}...
-								</p>
-							)}
-							{treatment && (
-								<p className="text-slate-600">
-									<span className="font-medium">Condition:</span> {treatment}
-								</p>
-							)}
-						</div>
-					)}
 				</>
 			)}
 

--- a/apps/lab/app/src/components/Matchmaking/runtime.tsx
+++ b/apps/lab/app/src/components/Matchmaking/runtime.tsx
@@ -40,10 +40,6 @@ export const MatchmakingRuntime = defineRuntimeComponent<
 		const [status, setStatus] = useState<MatchmakingStatus>("connecting");
 		const [currentCount, setCurrentCount] = useState(1);
 		const [elapsedSeconds, setElapsedSeconds] = useState(0);
-		const [matchResult, setMatchResult] = useState<{
-			groupId?: string;
-			treatment?: string;
-		}>({});
 
 		const startTimeRef = useRef<number>(Date.now());
 		const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -72,10 +68,6 @@ export const MatchmakingRuntime = defineRuntimeComponent<
 
 				// Update status
 				setStatus("matched");
-				setMatchResult({
-					groupId: data.groupId,
-					treatment: data.treatment,
-				});
 
 				// Update session state
 				if (onSessionStateChange) {
@@ -251,8 +243,6 @@ export const MatchmakingRuntime = defineRuntimeComponent<
 				targetCount={targetCount}
 				timeoutSeconds={timeoutSeconds}
 				elapsedSeconds={elapsedSeconds}
-				groupId={matchResult.groupId}
-				treatment={matchResult.treatment}
 				onCancel={status === "waiting" ? handleCancel : undefined}
 			/>
 		);


### PR DESCRIPTION
## Summary
- Stop showing condition and group id on the matchmaking "Match found!" screen
- Keep writing treatment/group into session state for experiment logic

## Test plan
- [ ] Join matchmaking until matched
- [ ] Confirm UI shows "Match found!" without Condition/Group metadata
- [ ] Confirm session still has treatment/group_id set for downstream steps


Made with [Cursor](https://cursor.com)